### PR TITLE
Update accessibility permission subtitles (#1270)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2909,8 +2909,8 @@
     },
     "accessibilityPermissionVcInfoNew": {
         "title": "Concede permisos de Accesibilidad",
-        "subTitleMacOS13": "Para interactuar con otros navegadores, necesitas autorizar Focus Bear desde Preferencias del Sistema:\nPreferencias del Sistema > Privacidad y seguridad > Accesibilidad",
-        "subTitleLegacy": "Para interactuar con otros navegadores, necesitas autorizar Focus Bear desde Preferencias del Sistema:\nPreferencias del Sistema > Seguridad y privacidad > Privacidad > Accesibilidad",
+        "subTitleMacOS13": "Para bloquear distracciones, necesitas autorizar Focus Bear desde Preferencias del Sistema:\nPreferencias del Sistema > Privacidad y seguridad > Accesibilidad",
+        "subTitleLegacy": "Para bloquear distracciones, necesitas autorizar Focus Bear desde Preferencias del Sistema:\nPreferencias del Sistema > Seguridad y privacidad > Privacidad > Accesibilidad",
         "description": "Activa Focus Bear.",
         "buttonContinue": "Continuar",
         "buttonSkip": "Omitir",

--- a/config/config.json
+++ b/config/config.json
@@ -2911,8 +2911,8 @@
     },
     "accessibilityPermissionVcInfoNew": {
         "title": "Grant Accessibility Permissions",
-        "subTitleMacOS13": "In order to interact with other browsers, you need to authorise Focus Bear through System Preferences:\nSystem Preferences > Privacy & Security > Accessibility",
-        "subTitleLegacy": "In order to interact with other browsers, you need to authorise Focus Bear through System Preferences:\nSystem Preferences > Security & Privacy > Privacy > Accessibility",
+        "subTitleMacOS13": "In order to block distractions, you need to authorise Focus Bear through System Preferences:\nSystem Preferences > Privacy & Security > Accessibility",
+        "subTitleLegacy": "In order to block distractions, you need to authorise Focus Bear through System Preferences:\nSystem Preferences > Security & Privacy > Privacy > Accessibility",
         "description": "Toggle Focus Bear on.",
         "buttonContinue": "Proceed",
         "buttonSkip": "Skip",


### PR DESCRIPTION
## Summary

Follow-up Assets repository changes related to Issue #1270 on Mac-App repository.

Updates the Accessibility permission subtitles in English and Spanish.

Changes:
- Replace "interact with other browsers" wording with "block distractions"
- Update both macOS 13+ and legacy subtitle variants
- Update translations in config-es.json