### PR TITLE
Add alertInvalidTime string for blocking schedule time validation

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2770,6 +2770,7 @@
         "buttonAddNewBlock": "Agregar nuevo bloqueo",
         "errorBlockListMissing": "Actualizar lista de bloqueo ⚠️",
         "alertSelectBlockList": "Por favor, selecciona una lista de bloqueo.",
+        "alertInvalidTime": "Por favor, ingresa una hora completa, incluyendo AM o PM, en los campos De y Hasta antes de guardar.",
         "titleScheduleOverlapAlert": "Se detectó un solapamiento de horarios.",
         "subTitleScheduleOverlapAlert": "El horario de bloqueo se superpone con uno existente. ¿Quieres guardarlo de todos modos?",
         "buttonSaveBlockAnyway": "Guardar de todos modos",

--- a/config/config.json
+++ b/config/config.json
@@ -2772,6 +2772,7 @@
         "buttonAddNewBlock": "Add new block",
         "errorBlockListMissing": "Update block list ⚠️",
         "alertSelectBlockList": "Please select block list.",
+        "alertInvalidTime": "Please enter a complete time, including AM or PM, in the From and Till fields before saving.",
         "titleScheduleOverlapAlert": "Time Overlap Detected",
         "subTitleScheduleOverlapAlert": "This blocking schedule's time overlaps with an existing one. Do you want to save it anyway?",
         "buttonSaveBlockAnyway": "Save Anyway",


### PR DESCRIPTION
Adds the alertInvalidTime key to blockingScheduleEditorVcInfo in both config.json and config-es.json.

This string is shown by the Windows app (PR: https://github.com/Focus-Bear/windows-app-v2/pull/1265) when the From or Till time field is incomplete or invalid on Save. Covers missing hour, missing minute, and missing AM/PM.