### PR TITLE
Add titleCuddlyDailyCap and descriptionCuddlyDailyCap strings for Cuddly Bear daily cap setting

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -583,6 +583,8 @@
         "titleAppMode": "Modo de Focus Bear:",
         "checkBoxCuddlyBearText": "Modo Osito de Peluche",
         "descriptionCuddlyBearText": "Modo Osito de Peluche: amable y gentil: te da el beneficio de la duda cuando abres una URL no permitida. Te deja permitir temporalmente las URL bloqueadas durante un modo de enfoque.",
+        "titleCuddlyDailyCap": "Límite diario para sitios distractores (minutos):",
+        "descriptionCuddlyDailyCap": "El tiempo total máximo por día que puedes desbloquear temporalmente sitios distractores en el modo Osito de Peluche. Una vez que lo alcanzas, esos sitios permanecen bloqueados hasta el día siguiente.",
         "checkBoxGrizzlyBearText": "Modo Oso Pardo",
         "descriptionGrizzlyBearText": "Modo Oso Pardo: súper estricto: bloquea inmediatamente las URL que no están permitidas y no se permite habilitarlas hasta que finalices el modo de enfoque.",
         "pomodoroDescriptionText": "Las Sesiones de Enfoque (modo pomodoro) alternan entre bloques de trabajo profundo en los que se activa el modo de enfoque (y se desactivan las distracciones) y periodos de descanso.",

--- a/config/config.json
+++ b/config/config.json
@@ -570,6 +570,8 @@
         "titleAppMode": "Focus bear mode:",
         "checkBoxCuddlyBearText": "Cuddly Bear mode",
         "descriptionCuddlyBearText": "Cuddly Bear mode: kind and gentle - gives you the benefit of the doubt when you open a non-allowed URL. Lets you temporarily allow blocked URLs during a focus mode.",
+        "titleCuddlyDailyCap": "Daily limit for distracting sites (minutes):",
+        "descriptionCuddlyDailyCap": "The maximum total time per day you can temporarily unblock distracting sites in Cuddly Bear mode. Once you reach it, those sites stay blocked until the next day.",
         "checkBoxGrizzlyBearText": "Grizzly Bear mode",
         "descriptionGrizzlyBearText": "Grizzly Bear mode: super strict - immediately block URLs that aren't allowed and don't let yourself allow them until the focus mode is over.",
         "pomodoroDescriptionText": "Focus Sessions (pomodoro mode) cycles between deep work blocks where a focus mode is turned on (and distractions turned off) and break periods.",


### PR DESCRIPTION
Adds the titleCuddlyDailyCap and descriptionCuddlyDailyCap keys to preferencesInfo in both config.json and config-es.json.

These strings are shown by the Windows app (PR: https://github.com/Focus-Bear/windows-app-v2/pull/1234) in the Focus Mode settings tab when Cuddly Bear mode is selected. titleCuddlyDailyCap is the label for the daily time limit spinner and descriptionCuddlyDailyCap explains what the cap does and what happens when it's reached.