### PR TITLE
chore: rename Habits nav item to Schedule

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2699,6 +2699,28 @@
         "noBreakAddedText": "Aún no se han agregado actividades de descanso.",
         "buttonChangeTiming": "Cambiar horario"
     },
+    "scheduleViewInfo":{
+        "morningRoutineHabits": "Hábitos de la rutina matutina",
+        "eveningRoutineHabits": "Hábitos de la rutina nocturna",
+        "habitsSuffix": "hábitos",
+        "play": "Iniciar",
+        "done": "Hecho",
+        "skip": "Saltar",
+        "habitsDone": "Hábitos completados",
+        "meeting": "reunión",
+        "meetingDefaultTitle": "Reunión",
+        "deepWork": "Trabajo profundo",
+        "deepWorkNoRoom": "Trabajo profundo (sin espacio para el siguiente hábito)",
+        "sleep": "Dormir",
+        "eveningRoutine": "Rutina nocturna",
+        "morningRoutine": "Rutina matutina",
+        "noHabitsLeft": "No quedan hábitos por ahora: ¡disfruta tu tiempo libre! 🎉",
+        "nothingScheduled": "Nada programado para este día.",
+        "calendarBanner": "Conecta tu calendario para ver reuniones y tiempo libre para trabajo profundo.",
+        "grantAccess": "Conceder acceso",
+        "removingFullScreen": "Quitando pantalla completa durante 30 segundos para conceder permisos de calendario",
+        "today": "Hoy"
+    },
     "leftMenuVcInfo":{
         "titleMain": "PRINCIPAL",
         "titleTools": "HERRAMIENTAS",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2719,7 +2719,8 @@
         "calendarBanner": "Conecta tu calendario para ver reuniones y tiempo libre para trabajo profundo.",
         "grantAccess": "Conceder acceso",
         "removingFullScreen": "Quitando pantalla completa durante 30 segundos para conceder permisos de calendario",
-        "today": "Hoy"
+        "today": "Hoy",
+        "backToToday": "Volver a hoy"
     },
     "leftMenuVcInfo":{
         "titleMain": "PRINCIPAL",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2728,7 +2728,10 @@
         "eventEndsLabel": "Termina",
         "eventSave": "Guardar",
         "eventCancel": "Cancelar",
-        "eventSaveError": "No se pudo guardar el evento. Comprueba el acceso al calendario e inténtalo de nuevo."
+        "eventSaveError": "No se pudo guardar el evento. Comprueba el acceso al calendario e inténtalo de nuevo.",
+        "showEarlierEvents": "Mostrar eventos anteriores de hoy",
+        "hideEarlierEvents": "Ocultar eventos anteriores de hoy",
+        "viewTomorrow": "Ver el horario de mañana"
     },
     "leftMenuVcInfo":{
         "titleMain": "PRINCIPAL",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2746,7 +2746,8 @@
         "tasksEmpty": "Aún no hay tareas. Añade una desde cero o desde tu lista de tareas.",
         "tasksSearchPlaceholder": "Buscar tareas…",
         "tasksAllProjects": "Todos los proyectos",
-        "tasksAddSelected": "Añadir"
+        "tasksAddSelected": "Añadir",
+        "tasksNamePlaceholder": "Nombre de la tarea"
     },
     "leftMenuVcInfo":{
         "titleMain": "PRINCIPAL",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2720,7 +2720,15 @@
         "grantAccess": "Conceder acceso",
         "removingFullScreen": "Quitando pantalla completa durante 30 segundos para conceder permisos de calendario",
         "today": "Hoy",
-        "backToToday": "Volver a hoy"
+        "backToToday": "Volver a hoy",
+        "addEvent": "Añadir evento",
+        "eventTitlePlaceholder": "Título del evento",
+        "eventCalendarLabel": "Calendario",
+        "eventStartsLabel": "Empieza",
+        "eventEndsLabel": "Termina",
+        "eventSave": "Guardar",
+        "eventCancel": "Cancelar",
+        "eventSaveError": "No se pudo guardar el evento. Comprueba el acceso al calendario e inténtalo de nuevo."
     },
     "leftMenuVcInfo":{
         "titleMain": "PRINCIPAL",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2732,7 +2732,14 @@
         "eventSaveError": "No se pudo guardar el evento. Comprueba el acceso al calendario e inténtalo de nuevo.",
         "showEarlierEvents": "Mostrar eventos anteriores de hoy",
         "hideEarlierEvents": "Ocultar eventos anteriores de hoy",
-        "viewTomorrow": "Ver el horario de mañana"
+        "viewTomorrow": "Ver el horario de mañana",
+        "editEventTitle": "Editar evento",
+        "eventRepeatLabel": "Repetir",
+        "eventColorLabel": "Color",
+        "repeatNone": "No se repite",
+        "repeatDaily": "Cada día",
+        "repeatWeekly": "Cada semana",
+        "repeatMonthly": "Cada mes"
     },
     "leftMenuVcInfo":{
         "titleMain": "PRINCIPAL",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2749,7 +2749,9 @@
         "tasksAddSelected": "Añadir",
         "tasksNamePlaceholder": "Nombre de la tarea",
         "tasksDragHint": "Arrastra a un bloque para programarla",
-        "tasksReturnToPanel": "Devolver a tareas"
+        "tasksReturnToPanel": "Devolver a tareas",
+        "tasksTimeBoxed": "Con tiempo asignado",
+        "tasksNotTimeBoxed": "Sin tiempo asignado"
     },
     "leftMenuVcInfo":{
         "titleMain": "PRINCIPAL",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2747,7 +2747,9 @@
         "tasksSearchPlaceholder": "Buscar tareas…",
         "tasksAllProjects": "Todos los proyectos",
         "tasksAddSelected": "Añadir",
-        "tasksNamePlaceholder": "Nombre de la tarea"
+        "tasksNamePlaceholder": "Nombre de la tarea",
+        "tasksDragHint": "Arrastra a un bloque para programarla",
+        "tasksReturnToPanel": "Devolver a tareas"
     },
     "leftMenuVcInfo":{
         "titleMain": "PRINCIPAL",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2710,6 +2710,7 @@
         "meeting": "reunión",
         "meetingDefaultTitle": "Reunión",
         "deepWork": "Trabajo profundo",
+        "breakSprint": "Descanso",
         "deepWorkNoRoom": "Trabajo profundo (sin espacio para el siguiente hábito)",
         "sleep": "Dormir",
         "eveningRoutine": "Rutina nocturna",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2739,13 +2739,21 @@
         "repeatNone": "No se repite",
         "repeatDaily": "Cada día",
         "repeatWeekly": "Cada semana",
-        "repeatMonthly": "Cada mes"
+        "repeatMonthly": "Cada mes",
+        "tasksForToday": "Tareas de hoy",
+        "tasksAddNew": "Añadir tarea",
+        "tasksAddFromList": "De la lista de tareas",
+        "tasksEmpty": "Aún no hay tareas. Añade una desde cero o desde tu lista de tareas.",
+        "tasksSearchPlaceholder": "Buscar tareas…",
+        "tasksAllProjects": "Todos los proyectos",
+        "tasksAddSelected": "Añadir"
     },
     "leftMenuVcInfo":{
         "titleMain": "PRINCIPAL",
         "titleTools": "HERRAMIENTAS",
         "titlePreferences": "PREFERENCIAS",
-        "menuHabits": "Plan del día",
+        "menuHabits": "Hábitos",
+        "menuDayPlan": "Plan del día",
         "menuCustomRoutine": "Rutina personalizada",
         "menuStartFocusSession": "Iniciar sesión de enfoque",
         "menuStopFocusSession": "Detener sesión de enfoque",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2737,7 +2737,7 @@
         "titleMain": "PRINCIPAL",
         "titleTools": "HERRAMIENTAS",
         "titlePreferences": "PREFERENCIAS",
-        "menuHabits": "Horario",
+        "menuHabits": "Plan del día",
         "menuCustomRoutine": "Rutina personalizada",
         "menuStartFocusSession": "Iniciar sesión de enfoque",
         "menuStopFocusSession": "Detener sesión de enfoque",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2703,7 +2703,7 @@
         "titleMain": "PRINCIPAL",
         "titleTools": "HERRAMIENTAS",
         "titlePreferences": "PREFERENCIAS",
-        "menuHabits": "Hábitos",
+        "menuHabits": "Horario",
         "menuCustomRoutine": "Rutina personalizada",
         "menuStartFocusSession": "Iniciar sesión de enfoque",
         "menuStopFocusSession": "Detener sesión de enfoque",

--- a/config/config.json
+++ b/config/config.json
@@ -2701,6 +2701,28 @@
         "noBreakAddedText": "No break activities added yet.",
         "buttonChangeTiming": "Change Timing"
     },
+    "scheduleViewInfo":{
+        "morningRoutineHabits": "Morning routine habits",
+        "eveningRoutineHabits": "Evening routine habits",
+        "habitsSuffix": "habits",
+        "play": "Play",
+        "done": "Done",
+        "skip": "Skip",
+        "habitsDone": "Habits done",
+        "meeting": "meeting",
+        "meetingDefaultTitle": "Meeting",
+        "deepWork": "Deep work",
+        "deepWorkNoRoom": "Deep work (no room for next habit)",
+        "sleep": "Sleep",
+        "eveningRoutine": "Evening routine",
+        "morningRoutine": "Morning routine",
+        "noHabitsLeft": "No habits left for now — enjoy your free time! 🎉",
+        "nothingScheduled": "Nothing scheduled for this day.",
+        "calendarBanner": "Connect your calendar to see meetings and free time for deep work.",
+        "grantAccess": "Grant access",
+        "removingFullScreen": "Removing full screen for 30 seconds to grant calendar permissions",
+        "today": "Today"
+    },
     "leftMenuVcInfo":{
         "titleMain": "MAIN",
         "titleTools": "TOOLS",

--- a/config/config.json
+++ b/config/config.json
@@ -2712,6 +2712,7 @@
         "meeting": "meeting",
         "meetingDefaultTitle": "Meeting",
         "deepWork": "Deep work",
+        "breakSprint": "Break",
         "deepWorkNoRoom": "Deep work (no room for next habit)",
         "sleep": "Sleep",
         "eveningRoutine": "Evening routine",

--- a/config/config.json
+++ b/config/config.json
@@ -2721,7 +2721,8 @@
         "calendarBanner": "Connect your calendar to see meetings and free time for deep work.",
         "grantAccess": "Grant access",
         "removingFullScreen": "Removing full screen for 30 seconds to grant calendar permissions",
-        "today": "Today"
+        "today": "Today",
+        "backToToday": "Back to today"
     },
     "leftMenuVcInfo":{
         "titleMain": "MAIN",

--- a/config/config.json
+++ b/config/config.json
@@ -2741,13 +2741,21 @@
         "repeatNone": "Does not repeat",
         "repeatDaily": "Daily",
         "repeatWeekly": "Weekly",
-        "repeatMonthly": "Monthly"
+        "repeatMonthly": "Monthly",
+        "tasksForToday": "Tasks for today",
+        "tasksAddNew": "Add task",
+        "tasksAddFromList": "From to-do list",
+        "tasksEmpty": "No tasks yet. Add one from scratch or from your to-do list.",
+        "tasksSearchPlaceholder": "Search tasks…",
+        "tasksAllProjects": "All projects",
+        "tasksAddSelected": "Add"
     },
     "leftMenuVcInfo":{
         "titleMain": "MAIN",
         "titleTools": "TOOLS",
         "titlePreferences": "PREFERENCES",
-        "menuHabits": "Day Plan",
+        "menuHabits": "Habits",
+        "menuDayPlan": "Day Plan",
         "menuCustomRoutine": "Custom Routine",
         "menuStartFocusSession": "Start Focus Session",
         "menuStopFocusSession": "Stop Focus Session",

--- a/config/config.json
+++ b/config/config.json
@@ -2705,7 +2705,7 @@
         "titleMain": "MAIN",
         "titleTools": "TOOLS",
         "titlePreferences": "PREFERENCES",
-        "menuHabits": "Habits",
+        "menuHabits": "Schedule",
         "menuCustomRoutine": "Custom Routine",
         "menuStartFocusSession": "Start Focus Session",
         "menuStopFocusSession": "Stop Focus Session",

--- a/config/config.json
+++ b/config/config.json
@@ -2749,7 +2749,9 @@
         "tasksSearchPlaceholder": "Search tasks…",
         "tasksAllProjects": "All projects",
         "tasksAddSelected": "Add",
-        "tasksNamePlaceholder": "Task name"
+        "tasksNamePlaceholder": "Task name",
+        "tasksDragHint": "Drag onto a block to schedule it",
+        "tasksReturnToPanel": "Move back to tasks"
     },
     "leftMenuVcInfo":{
         "titleMain": "MAIN",

--- a/config/config.json
+++ b/config/config.json
@@ -2730,7 +2730,10 @@
         "eventEndsLabel": "Ends",
         "eventSave": "Save",
         "eventCancel": "Cancel",
-        "eventSaveError": "Couldn't save the event. Check calendar access and try again."
+        "eventSaveError": "Couldn't save the event. Check calendar access and try again.",
+        "showEarlierEvents": "Show events from earlier today",
+        "hideEarlierEvents": "Hide events from earlier today",
+        "viewTomorrow": "View tomorrow's schedule"
     },
     "leftMenuVcInfo":{
         "titleMain": "MAIN",

--- a/config/config.json
+++ b/config/config.json
@@ -2739,7 +2739,7 @@
         "titleMain": "MAIN",
         "titleTools": "TOOLS",
         "titlePreferences": "PREFERENCES",
-        "menuHabits": "Schedule",
+        "menuHabits": "Day Plan",
         "menuCustomRoutine": "Custom Routine",
         "menuStartFocusSession": "Start Focus Session",
         "menuStopFocusSession": "Stop Focus Session",

--- a/config/config.json
+++ b/config/config.json
@@ -2722,7 +2722,15 @@
         "grantAccess": "Grant access",
         "removingFullScreen": "Removing full screen for 30 seconds to grant calendar permissions",
         "today": "Today",
-        "backToToday": "Back to today"
+        "backToToday": "Back to today",
+        "addEvent": "Add event",
+        "eventTitlePlaceholder": "Event title",
+        "eventCalendarLabel": "Calendar",
+        "eventStartsLabel": "Starts",
+        "eventEndsLabel": "Ends",
+        "eventSave": "Save",
+        "eventCancel": "Cancel",
+        "eventSaveError": "Couldn't save the event. Check calendar access and try again."
     },
     "leftMenuVcInfo":{
         "titleMain": "MAIN",

--- a/config/config.json
+++ b/config/config.json
@@ -2751,7 +2751,9 @@
         "tasksAddSelected": "Add",
         "tasksNamePlaceholder": "Task name",
         "tasksDragHint": "Drag onto a block to schedule it",
-        "tasksReturnToPanel": "Move back to tasks"
+        "tasksReturnToPanel": "Move back to tasks",
+        "tasksTimeBoxed": "Time boxed",
+        "tasksNotTimeBoxed": "Not yet time boxed"
     },
     "leftMenuVcInfo":{
         "titleMain": "MAIN",

--- a/config/config.json
+++ b/config/config.json
@@ -2734,7 +2734,14 @@
         "eventSaveError": "Couldn't save the event. Check calendar access and try again.",
         "showEarlierEvents": "Show events from earlier today",
         "hideEarlierEvents": "Hide events from earlier today",
-        "viewTomorrow": "View tomorrow's schedule"
+        "viewTomorrow": "View tomorrow's schedule",
+        "editEventTitle": "Edit event",
+        "eventRepeatLabel": "Repeat",
+        "eventColorLabel": "Colour",
+        "repeatNone": "Does not repeat",
+        "repeatDaily": "Daily",
+        "repeatWeekly": "Weekly",
+        "repeatMonthly": "Monthly"
     },
     "leftMenuVcInfo":{
         "titleMain": "MAIN",

--- a/config/config.json
+++ b/config/config.json
@@ -2748,7 +2748,8 @@
         "tasksEmpty": "No tasks yet. Add one from scratch or from your to-do list.",
         "tasksSearchPlaceholder": "Search tasks…",
         "tasksAllProjects": "All projects",
-        "tasksAddSelected": "Add"
+        "tasksAddSelected": "Add",
+        "tasksNamePlaceholder": "Task name"
     },
     "leftMenuVcInfo":{
         "titleMain": "MAIN",


### PR DESCRIPTION
The Mac app's left-nav item now opens the Schedule view (a timetable of habits + meetings + deep-work), so the label should read **Schedule** instead of **Habits**.

- config.json: menuHabits → "Schedule"
- config-es.json: menuHabits → "Horario"

Paired with the Mac-App change (calendar icon + "Schedule" fallback) on Focus-Bear/Mac-App#1935.

🤖 Generated with [Claude Code](https://claude.com/claude-code)