### PR TITLE
Day Plan project strings + restore snooze strings (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2773,7 +2773,15 @@
         "tasksDragHint": "Arrastra a un bloque para programarla",
         "tasksReturnToPanel": "Devolver a tareas",
         "tasksTimeBoxed": "Con tiempo asignado",
-        "tasksNotTimeBoxed": "Sin tiempo asignado"
+        "tasksNotTimeBoxed": "Sin tiempo asignado",
+        "tasksSnoozeHint": "Posponer — mover a otro día",
+        "tasksSnoozeTitle": "Mover tarea a…",
+        "tasksSnoozePlaceholder": "p. ej. 2d, 2w, tue, tom",
+        "tasksSnoozeHelp": "2d = en 2 días · 2w = en 2 semanas · tue = próximo martes · tom = mañana",
+        "tasksSnoozeConfirm": "Mover",
+        "tasksSnoozeCancel": "Cancelar",
+        "tasksNoProject": "Sin proyecto",
+        "tasksProjectHint": "Escribe #proyecto para agrupar esta tarea"
     },
     "leftMenuVcInfo":{
         "titleMain": "PRINCIPAL",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2781,7 +2781,11 @@
         "tasksSnoozeConfirm": "Mover",
         "tasksSnoozeCancel": "Cancelar",
         "tasksNoProject": "Sin proyecto",
-        "tasksProjectHint": "Escribe #proyecto para agrupar esta tarea"
+        "tasksProjectHint": "Escribe #proyecto para agrupar esta tarea",
+        "customRoutinesTitle": "Rutinas personalizadas",
+        "customRoutinesEmpty": "No hay rutinas a demanda",
+        "tabCustomRoutine": "Rutina personalizada",
+        "tabDayPlan": "Plan del día"
     },
     "leftMenuVcInfo":{
         "titleMain": "PRINCIPAL",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2784,6 +2784,7 @@
         "tasksProjectHint": "Escribe #proyecto para agrupar esta tarea",
         "customRoutinesTitle": "Rutinas personalizadas",
         "customRoutinesEmpty": "No hay rutinas a demanda",
+        "customRoutinesAfterCutoff": "Las rutinas personalizadas a demanda se desactivan hasta mañana por la mañana: es hora de ir terminando",
         "tabCustomRoutine": "Rutina personalizada",
         "tabDayPlan": "Plan del día"
     },

--- a/config/config.json
+++ b/config/config.json
@@ -2786,6 +2786,7 @@
         "tasksProjectHint": "Type #project to group this task",
         "customRoutinesTitle": "Custom routines",
         "customRoutinesEmpty": "No on-demand routines",
+        "customRoutinesAfterCutoff": "On demand custom routines deactivated until tomorrow morning - time to wind down now",
         "tabCustomRoutine": "Custom routine",
         "tabDayPlan": "Day Plan"
     },

--- a/config/config.json
+++ b/config/config.json
@@ -2775,7 +2775,15 @@
         "tasksDragHint": "Drag onto a block to schedule it",
         "tasksReturnToPanel": "Move back to tasks",
         "tasksTimeBoxed": "Time boxed",
-        "tasksNotTimeBoxed": "Not yet time boxed"
+        "tasksNotTimeBoxed": "Not yet time boxed",
+        "tasksSnoozeHint": "Snooze — move to another day",
+        "tasksSnoozeTitle": "Move task to…",
+        "tasksSnoozePlaceholder": "e.g. 2d, 2w, tue, tom",
+        "tasksSnoozeHelp": "2d = in 2 days · 2w = in 2 weeks · tue = next Tuesday · tom = tomorrow",
+        "tasksSnoozeConfirm": "Move",
+        "tasksSnoozeCancel": "Cancel",
+        "tasksNoProject": "No project",
+        "tasksProjectHint": "Type #project to group this task"
     },
     "leftMenuVcInfo":{
         "titleMain": "MAIN",

--- a/config/config.json
+++ b/config/config.json
@@ -2783,7 +2783,11 @@
         "tasksSnoozeConfirm": "Move",
         "tasksSnoozeCancel": "Cancel",
         "tasksNoProject": "No project",
-        "tasksProjectHint": "Type #project to group this task"
+        "tasksProjectHint": "Type #project to group this task",
+        "customRoutinesTitle": "Custom routines",
+        "customRoutinesEmpty": "No on-demand routines",
+        "tabCustomRoutine": "Custom routine",
+        "tabDayPlan": "Day Plan"
     },
     "leftMenuVcInfo":{
         "titleMain": "MAIN",


### PR DESCRIPTION
Adds `tasksNoProject` / `tasksProjectHint` for the macOS Day Plan project grouping + `#`-autocomplete feature (Mac-App PR #1935).

Also **restores the snooze strings** (`tasksSnoozeHint/Title/Placeholder/Help/Confirm/Cancel`) which were merged in #350 but are no longer present on `main` — they appear to have been clobbered by a later text-update merge (#352). Without them the Mac app falls back to English defaults.

Both `config.json` (EN) and `config-es.json` (ES) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)