### PR TITLE
Add unsaved-changes prompt strings for Settings (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -429,6 +429,8 @@
         "settingIsValidText": "¡Guardado! Reiniciando la app para que tu nuevo horario de hábitos funcione.",
         "settingsEditedButNotSavedText": "Has hecho cambios en tus hábitos/descansos pero aún no los has guardado. Se recomienda revisar y guardar los cambios (la aplicación se reiniciará)",
         "buttonReviewSettingsText": "Revisaré y Guardaré",
+        "buttonDiscardChangesText": "Descartar cambios",
+        "settingsChangesNotSavedText": "Has hecho cambios en tus ajustes pero aún no los has guardado. ¿Quieres revisarlos y guardarlos?",
         "downloadReportText": "Visita el panel de control de Focus Bear en tu navegador web para descargar el informe.",
         "buttonVisitDashboardText": "Haz clic aquí para visitar el panel de control",
         "tokenErrorText": "Sesión expirada. Por favor, inicia sesión de nuevo.",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -430,6 +430,7 @@
         "settingsEditedButNotSavedText": "Has hecho cambios en tus hábitos/descansos pero aún no los has guardado. Se recomienda revisar y guardar los cambios (la aplicación se reiniciará)",
         "buttonReviewSettingsText": "Revisaré y Guardaré",
         "buttonDiscardChangesText": "Descartar cambios",
+        "buttonReviewChangesText": "Revisar cambios",
         "settingsChangesNotSavedText": "Has hecho cambios en tus ajustes pero aún no los has guardado. ¿Quieres revisarlos y guardarlos?",
         "downloadReportText": "Visita el panel de control de Focus Bear en tu navegador web para descargar el informe.",
         "buttonVisitDashboardText": "Haz clic aquí para visitar el panel de control",

--- a/config/config.json
+++ b/config/config.json
@@ -418,6 +418,7 @@
         "settingsEditedButNotSavedText": "You've made changes to your habits/breaks but haven't saved them yet. It is recommended to review and save the changes (the app will restart)?",
         "buttonReviewSettingsText": "I'll review and Save",
         "buttonDiscardChangesText": "Discard changes",
+        "buttonReviewChangesText": "Review changes",
         "settingsChangesNotSavedText": "You've made changes to your settings but haven't saved them yet. Would you like to review and save them?",
         "downloadReportText": "Please visit Focus Bear dashboard in your web browser to download the report.",
         "buttonVisitDashboardText": "Click here to visit dashboard now",

--- a/config/config.json
+++ b/config/config.json
@@ -417,6 +417,8 @@
         "settingIsValidText": "Saved! Restarting the app so your new habit timing works.",
         "settingsEditedButNotSavedText": "You've made changes to your habits/breaks but haven't saved them yet. It is recommended to review and save the changes (the app will restart)?",
         "buttonReviewSettingsText": "I'll review and Save",
+        "buttonDiscardChangesText": "Discard changes",
+        "settingsChangesNotSavedText": "You've made changes to your settings but haven't saved them yet. Would you like to review and save them?",
         "downloadReportText": "Please visit Focus Bear dashboard in your web browser to download the report.",
         "buttonVisitDashboardText": "Click here to visit dashboard now",
         "tokenErrorText": "Session Expired. Please login again.",


### PR DESCRIPTION
Adds 3 new keys to the `settings` section in both `config.json` and `config-es.json`.

These strings are used by the Windows app (PR: https://github.com/Focus-Bear/windows-app-v2/pull/1242) for the unsaved-changes confirmation prompt that appears when the user navigates away from Settings or closes the window with unsaved changes.

Keys added:
- `settingsChangesNotSavedText` — body text of the prompt
- `buttonReviewChangesText` — Yes button ("Review changes" / "Revisar cambios")
- `buttonDiscardChangesText` — No button ("Discard changes" / "Descartar cambios")