### PR TITLE
Truncate long URLs in blocked page UI

### DIFF
--- a/focus-blocked/js/main.js
+++ b/focus-blocked/js/main.js
@@ -63,7 +63,9 @@ try {
     if (old_url) {
       focusBlockedOriginalUrl.style.display = 'inline-block';
       focusBlockedOriginalUrl.setAttribute('href', current_url);
-      focusBlockedOriginalUrl.textContent = selected_lang.original_url(old_url);
+      focusBlockedOriginalUrl.textContent = selected_lang.original_url(
+        truncateUrlForDisplay(old_url)
+      );
       focusBlockedOriginalUrl.setAttribute('title', old_url);
     } else {
       focusBlockedOriginalUrl.style.display = 'none';
@@ -106,7 +108,9 @@ try {
             focusBlockedOriginalUrl.style.display = 'inline-block';
             focusBlockedOriginalUrl.setAttribute('href', current_url);
             focusBlockedOriginalUrl.textContent =
-              selected_lang.click_here_to_re_open_the_original_url(old_url);
+              selected_lang.click_here_to_re_open_the_original_url(
+                truncateUrlForDisplay(old_url)
+              );
             focusBlockedOriginalUrl.setAttribute('title', old_url);
           } else {
             focusBlockedOriginalUrl.style.display = 'none';
@@ -133,7 +137,9 @@ try {
             : 'none';
           focusBlockedOriginalUrl.setAttribute('href', current_url);
           focusBlockedOriginalUrl.textContent =
-            selected_lang.click_here_to_re_open_the_original_url(old_url);
+            selected_lang.click_here_to_re_open_the_original_url(
+              truncateUrlForDisplay(old_url)
+            );
           focusBlockedOriginalUrl.setAttribute('title', old_url);
           localStorage.removeItem(LOCAL_STORAGE.IS_PAGE_LOADED);
           localStorage.removeItem(LOCAL_STORAGE.IS_PAGE_RELOADED);
@@ -151,8 +157,10 @@ try {
 
   if (current_url) {
     const save_page_url_btn = document.createElement('a');
-    save_page_url_btn.innerHTML =
-      selected_lang.save_this_page_for_later(current_url);
+    save_page_url_btn.innerHTML = selected_lang.save_this_page_for_later(
+      truncateUrlForDisplay(current_url)
+    );
+    save_page_url_btn.setAttribute('title', current_url);
     save_page_url_btn.setAttribute(
       'href',
       `https://dashboard.focusbear.io/todo?tab=procrastinate&url=${encodeURI(

--- a/focus-blocked/js/utils.js
+++ b/focus-blocked/js/utils.js
@@ -7,6 +7,28 @@ function isValidUrl(string) {
   }
 }
 
+// Returns a shortened, query-string-free version of a URL for display in the
+// UI. The full URL is still used for the actual link (href) — this only
+// affects the visible text so long URLs don't blow out the layout.
+function truncateUrlForDisplay(url, maxLength = 60) {
+  if (!url) return '';
+  let display = url;
+  try {
+    const parsed = new URL(
+      url.startsWith('http') ? url : `https://${url}`
+    );
+    // Drop the query string and hash; keep origin + path.
+    display = `${parsed.origin}${parsed.pathname}`;
+  } catch (_) {
+    // Not a parseable URL — fall back to stripping the query/hash manually.
+    display = url.split(/[?#]/)[0];
+  }
+  if (display.length > maxLength) {
+    display = `${display.substring(0, maxLength - 1)}…`;
+  }
+  return display;
+}
+
 function logError(
   data,
   message = 'Invalid value for old_url query param',


### PR DESCRIPTION
## Problem

When a blocked URL has a long query string (e.g. Cloudflare login redirects), the blocked page rendered the full URL as visible link text, producing a huge multi-line wall of characters that broke the layout.

## Fix

Added a `truncateUrlForDisplay()` helper in `utils.js` that:
- strips the query string and hash (keeps origin + path)
- caps the result length (default 60 chars) with an ellipsis

Applied it to the **display text** of:
- the "Save … for later" button
- the "Original URL …" / "Click here to re-open the original URL …" links

The actual link `href` still uses the full URL, so clicking saves/opens the complete link. Each shortened element also gets a `title` attribute with the full URL for hover.

## Verification

- `node --check` passes on both edited files.
- `utils.js` loads before `init.js`/`main.js` in `index.html`, so the global helper is available at render time.
- Static page (GitHub Pages) — no build step required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)