### PR TITLE
Fix appAppearanceOptions array to separate Automatically as 4th element (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -629,7 +629,7 @@
         "checkBoxFullScreenEnabledText": "Reproducir hábitos en modo pantalla completa",
         "checkBoxAutoCloseAfterRoutineText": "Cerrar ventana automáticamente al completar, omitir o posponer una rutina",
         "titleDarkMode": "Modo Oscuro:",
-        "appAppearanceOptions": ["Copiar Preferencias del Sistema", "Siempre en Modo Oscuro", "Nunca en Modo Oscuro, Automáticamente"],
+        "appAppearanceOptions": ["Copiar Preferencias del Sistema", "Siempre en Modo Oscuro", "Nunca en Modo Oscuro", "Automáticamente"],
         "titleAnnouncement": "Anuncio:",
         "checkBoxAnnouncementText": "Anuncio después de cada actividad",
         "checkBoxShowBreaksInCallText": "Mostrar descansos durante llamadas",

--- a/config/config.json
+++ b/config/config.json
@@ -617,7 +617,7 @@
     	"checkBoxFullScreenEnabledText": "Play habits in full screen mode",
         "checkBoxAutoCloseAfterRoutineText": "Automatically close window after completing, skipping or postponing a routine",
         "titleDarkMode": "Dark Mode:",
-        "appAppearanceOptions": ["Copy system preferences", "Always Dark Mode", "Never Dark Mode, Automatically"],
+        "appAppearanceOptions": ["Copy system preferences", "Always Dark Mode", "Never Dark Mode", "Automatically"],
         "titleAnnouncement": "Announcement:",
         "checkBoxAnnouncementText": "Announcement after each activity",
         "checkBoxShowBreaksInCallText": "Show breaks while in call or in presentation mode",


### PR DESCRIPTION
Fixes the `appAppearanceOptions` array in `preferencesInfo` by properly separating all four theme mode options instead of having only three.

Added the missing 4th element "Automatically" / "Automáticamente" to support the new Clock mode theme switcher implemented in windows-app-v2 PR: https://github.com/Focus-Bear/windows-app-v2/pull/1078 (issue: https://github.com/Focus-Bear/windows-app-v2/issues/104).