### PR TITLE
Add logsUploadErrorConnectionText string for logs upload connection error (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2106,6 +2106,7 @@
         "placeHolderLogsFeedback": "¿Qué ha sucedido?",
         "logsUploadDoneText": "Registros compartidos con éxito.",
         "logsUploadErrorText": "Ha habido algún problema al cargar los registros. Por favor, inténtalo de nuevo.",
+        "logsUploadErrorConnectionText": "Se ha producido un problema con tu conexión a Internet al enviar los registros. Comprueba tu conexión e inténtalo de nuevo.",
         "tabCommunity": "Comunidad",
         "titleCommunity": "Únete al servidor de Discord de Focus Bear para compartir ideas, organizar sesiones de trabajo/doblaje de cuerpos y obtener ayuda con la aplicación.",
         "buttonJoinDiscordText": "Unirse al servidor Discord",

--- a/config/config.json
+++ b/config/config.json
@@ -2108,6 +2108,7 @@
         "placeHolderLogsFeedback": "What happened?",
         "logsUploadDoneText": "Logs successfully shared.",
         "logsUploadErrorText": "There was some problem in uploading the logs. Please try again.",
+        "logsUploadErrorConnectionText": "There was a problem with your Internet connection while uploading the logs. Please check your connection and try again.",
         "tabCommunity": "Community",
         "titleCommunity": "Join the Focus Bear discord server to share ideas, set up co-working/body doubling sessions and get help with the app.",
         "buttonJoinDiscordText": "Join Discord Server",


### PR DESCRIPTION
Adds the logsUploadErrorConnectionText key to helpVcInfo in both config.json and config-es.json.

This string is shown by the Windows app (PR: https://github.com/Focus-Bear/windows-app-v2/pull/1282) when sharing debug logs fails specifically because of a dropped Internet connection, instead of the generic upload error message. Related to windows-app-v2 issue: https://github.com/Focus-Bear/windows-app-v2/issues/959.