### PR TITLE
feat(config): add late-morning popup button strings (i18n)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2151,7 +2151,9 @@
         "title": "Hola, ¿todavía quieres hacer tu rutina matutina hoy o saltártela?",
         "subTitle": "(Pregunto porque son <HOUR> horas desde la hora de inicio de tu rutina y puede que no tenga sentido hacerlo hoy)",
         "buttonSkipText": "Saltarla",
-        "buttonDoHabitsText": "Hacer mis hábitos"
+        "buttonDoHabitsText": "Hacer mis hábitos",
+        "buttonPostponeText": "Ahora no",
+        "buttonSkipRoutineText": "Saltar rutina por hoy"
     },
     "settingsMeetingDetactionVcInfo": {
         "descriptionSuggestMeetingsFocusMode": "Al iniciar una videollamada, Focus Bear puede avisarte que inicies el modo de enfoque Reunión para ayudarte a mantener la concentración durante la reunión",

--- a/config/config.json
+++ b/config/config.json
@@ -2153,7 +2153,9 @@
         "title": "Hiya, do you still want to do your morning routine today or skip it?",
         "subTitle": "(Asking because it's <HOUR> hours since your routine start time and it might not make sense to do it today)",
         "buttonSkipText": "Skip it",
-        "buttonDoHabitsText": "Do my habits"
+        "buttonDoHabitsText": "Do my habits",
+        "buttonPostponeText": "Not now",
+        "buttonSkipRoutineText": "Skip routine for today"
     },
     "settingsMeetingDetactionVcInfo": {
         "descriptionSuggestMeetingsFocusMode": "When you start a video call, Focus Bear can prompt you to start the Meeting focus mode to help you stay focused during the meeting",


### PR DESCRIPTION
## What

Adds two new keys under `lateMorningHabitPopupVcInfo` in both `config/config.json` (English) and `config/config-es.json` (Spanish):

| Key | English | Spanish |
|-----|---------|---------|
| `buttonPostponeText` | Not now | Ahora no |
| `buttonSkipRoutineText` | Skip routine for today | Saltar rutina por hoy |

## Why

The Mac app's late-morning *"do you still want to do your morning routine today?"* popup was recently restructured into three buttons (Do my habits / Not now / Skip routine for today). The two new button titles were hardcoded in the app; this change makes them config-driven and translatable, matching the existing `buttonDoHabitsText` pattern.

The existing `buttonSkipText` ("Skip it") is intentionally left untouched — the new skip button has a different meaning ("skip the whole routine for today"), so a new key is used rather than repurposing the old one (which may also be used by the Windows app).

## Pairs with

The corresponding Mac-App change reads these keys with the hardcoded English strings as fallbacks, so this can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)