### PR TITLE
feat(day-plan): add cancel-routine confirmation strings (en + es)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2729,6 +2729,10 @@
         "buttonChangeTiming": "Cambiar horario"
     },
     "scheduleViewInfo":{
+        "cancelRoutineTitle": "¿Cancelar rutina?",
+        "cancelRoutineMessage": "Si cambias de opinión más tarde, puedes hacer clic en el botón «<BUTTON>» para restaurar la rutina.",
+        "cancelRoutineOk": "Aceptar",
+        "cancelRoutineCancel": "Cancelar",
         "morningRoutineHabits": "Hábitos de la rutina matutina",
         "eveningRoutineHabits": "Hábitos de la rutina nocturna",
         "habitsSuffix": "hábitos",

--- a/config/config.json
+++ b/config/config.json
@@ -2731,6 +2731,10 @@
         "buttonChangeTiming": "Change Timing"
     },
     "scheduleViewInfo":{
+        "cancelRoutineTitle": "Cancel Routine?",
+        "cancelRoutineMessage": "If you change your mind later, you can click the \"<BUTTON>\" button to restore the routine.",
+        "cancelRoutineOk": "OK",
+        "cancelRoutineCancel": "Cancel",
         "morningRoutineHabits": "Morning routine habits",
         "eveningRoutineHabits": "Evening routine habits",
         "habitsSuffix": "habits",


### PR DESCRIPTION
Adds the `scheduleViewInfo` strings for the Mac app's Day Plan **"Cancel Routine?"** confirmation alert (shown when the ✕ "skip routine for today" is clicked).

**Keys added to `config/config.json` + `config/config-es.json`:**
- `cancelRoutineTitle` — "Cancel Routine?" / "¿Cancelar rutina?"
- `cancelRoutineMessage` — uses a `<BUTTON>` placeholder, replaced at runtime with the relevant "Uncancel My Morning Routine" / "Uncancel My Evening Routine" button label so the message names only the routine being cancelled.
- `cancelRoutineOk` — "OK" / "Aceptar"
- `cancelRoutineCancel` — "Cancel" / "Cancelar"

The Mac app already has these in its bundled `config.json`/`config-es.json` with the same values and an English fallback; this ships them from the assets config too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)