### PR TITLE
feat: add focusMusicPromptInfo strings for Mac app's post-session music prompt

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2294,6 +2294,12 @@
         "buttonDontShowAgainText": "No volver a mostrar",
         "alertConfirmSwitchGeekModeDescription": "Puedes cambiar los modos desde Preferencias -> Configuración"
     },
+    "focusMusicPromptInfo": {
+        "title": "¿Quieres poner música de enfoque?",
+        "buttonYesText": "Sí, reproducir música",
+        "buttonNoText": "No, gracias",
+        "buttonDontAskAgainText": "No volver a preguntar"
+    },
     "takeBreaksInfoVcInfo":{
         "subTitle": "Focus Bear puede ayudarte a tomar pequeños descansos (de 30s a 2min) durante el día. Esto ayudará a evitar dolores de cabeza por la pantalla y, de hecho, mejorará tu productividad. Incluso puedes hacer microentrenamientos en los descansos 💪.",
         "warningText": "Advertencia: aparecerán ventanas emergentes pidiéndote que tomes descansos. Puedes saltarlos o posponerlos, pero tus ojos y tu cuerpo agradecerán que sí los hagas.",

--- a/config/config.json
+++ b/config/config.json
@@ -2296,6 +2296,12 @@
         "buttonDontShowAgainText": "Don't show again",
         "alertConfirmSwitchGeekModeDescription": "You can switch the modes from Preferences -> Settings tab"
     },
+    "focusMusicPromptInfo": {
+        "title": "Want to play some focus music?",
+        "buttonYesText": "Yes, play music",
+        "buttonNoText": "No thanks",
+        "buttonDontAskAgainText": "Don't ask again"
+    },
     "takeBreaksInfoVcInfo":{
         "subTitle": "Focus Bear can help you remember to take short breaks (30s to 2 minutes) regularly throughout the day. This will help avoid screen headaches and actually improve your productivity. You can even do microworkouts during the breaks 💪",
         "warningText": "Warning: you will get popups asking you to take breaks. You can skip/postpone the breaks but your eyes and body will really appreciate it if you do take breaks!",


### PR DESCRIPTION
Companion to Focus-Bear/Mac-App#2088 — adds the `focusMusicPromptInfo` config block (EN + ES) for the "Want to play some focus music?" alert shown right after a focus session starts on the Mac app.