### PR TITLE
Splash: jazzier customizing copy

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -134,7 +134,7 @@
         "andText": "y",
         "tabAccountsText": "Cuenta",
         "checkInternetText": "No se pudo conectar al servidor. Verifica tu conexión a Internet.",
-        "customizingText": "Personalizando Focus Bear según tus necesidades. Por favor espera..",
+        "customizingText": "Activando tus superpoderes de concentración...",
         "uninstallingText": "Desinstalando…",
         "askUninstallReasonText": "¿Puedes decirnos por qué estás desinstalando Focus Bear?",
         "buttonSelectReasonText": "Selecciona un Motivo",

--- a/config/config.json
+++ b/config/config.json
@@ -134,7 +134,7 @@
         "andText": "and",
         "tabAccountsText": "Account",
         "checkInternetText": "Unable to connect to server. Please check your internet connection.",
-        "customizingText": "Customizing Focus Bear per your needs. Please wait..",
+        "customizingText": "Warming up your focus superpowers...",
         "uninstallingText": "Uninstalling..",
         "askUninstallReasonText": "Can you share why you're uninstalling?",
         "buttonSelectReasonText": "Select a reason",


### PR DESCRIPTION
## What
Replaces the splash-screen "customizing" line:

- **Before:** `Customizing Focus Bear per your needs. Please wait..`
- **After:** `Warming up your focus superpowers...`

Spanish (`config-es.json`) updated to match: `Activando tus superpoderes de concentración...`

## Why
The old copy read flat/clerical. This is punchier and on-brand.

## Where it shows
`common.customizingText`, rendered on `SplashWindow` in the Windows app during the "customizing" load path. Served live to clients from `focus-bear.github.io/assets/config/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)