### PR TITLE
i18n: focus-music strings + full Mac-App config sync (en + es)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -1638,6 +1638,25 @@
         "titleVolumeText": "Volumen:",
         "downloadButtonText": "Descargar"
     },
+    "focusMusicPromptInfo": {
+        "title": "¿Quieres poner música de enfoque?",
+        "buttonYesText": "Sí, reproducir música",
+        "buttonNoText": "No, gracias",
+        "buttonDontAskAgainText": "Recordar mi elección"
+    },
+    "focusMusicInfo": {
+        "sectionTitleSpotify": "Spotify",
+        "sectionTitleYouTubeMusic": "YouTube Music",
+        "sectionTitleLibrary": "Biblioteca de música de enfoque",
+        "spotifyAddPlaceholder": "Pega un enlace de una canción, álbum o playlist de Spotify",
+        "youtubeAddPlaceholder": "Pega un enlace de music.youtube.com",
+        "addButtonText": "Añadir",
+        "youtubeHintText": "Añade un enlace de video o playlist de music.youtube.com para reproducirlo aquí.",
+        "addOwnMusicButtonText": "Añadir mi propia música",
+        "spotifyInvalidLinkError": "Eso no parece un enlace de una canción, álbum o playlist de Spotify.",
+        "spotifyNotInstalledError": "Spotify no está instalado en este Mac.",
+        "youtubeInvalidLinkError": "Eso no parece un enlace de music.youtube.com."
+    },
     "setUpVcInfo": {
         "title": "Configuración",
         "customiseFocusModeText": "Personalizar un modo de enfoque",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -1,4 +1,17 @@
 {
+    "talkingClockSettingsInfo":{
+        "title": "Reloj parlante",
+        "back": "Atrás",
+        "enableTitle": "Activar reloj parlante",
+        "enableSubtitle": "Anuncia la hora actual a intervalos regulares para ayudarte a mantener la conciencia del tiempo.",
+        "announceEvery": "Anunciar cada",
+        "minutes": "minutos",
+        "quietHours": "Horas de silencio (sin anuncios entre estas horas)",
+        "start": "Inicio:",
+        "end": "Fin:",
+        "suppressTitle": "Silenciar durante reuniones",
+        "suppressSubtitle": "No anunciar la hora cuando estás en un modo de enfoque de reunión."
+    },
     "focusButtonInfo":{
         "focusSessionEmoji": "Emoji de sesión de enfoque",
         "focusEmojiHint": "Elige hasta 5 emoji: el botón muestra uno al azar como protagonista cuando inicias una sesión de enfoque.",

--- a/config/config-es.json
+++ b/config/config-es.json
@@ -1,4 +1,43 @@
 {
+    "focusButtonInfo":{
+        "focusSessionEmoji": "Emoji de sesión de enfoque",
+        "focusEmojiHint": "Elige hasta 5 emoji: el botón muestra uno al azar como protagonista cuando inicias una sesión de enfoque.",
+        "save": "Guardar",
+        "habitIconsLabel": "Iconos de hábitos",
+        "focusIconsLabel": "Iconos de sesión de enfoque",
+        "iconsUpToDate": "actualizado",
+        "checkingHabitIcons": "Comprobando iconos de hábitos…",
+        "checkingFocusIcons": "Comprobando iconos de enfoque…"
+    },
+    "officeModeSettingsVcInfo":{
+        "settingTitle": "Modo oficina",
+        "descriptionText": "Durante el modo oficina, Focus Bear solo te dará hábitos de descanso apropiados para la oficina (p. ej. estiramientos en vez de flexiones).",
+        "officeModeOptionText": "Modo oficina",
+        "wfhModeOptionText": "Modo teletrabajo",
+        "autoSwitchSectionTitle": "Cambiar automáticamente según las redes Wi-Fi",
+        "autoSwitchDescription": "Focus Bear usa el modo Oficina de forma predeterminada y cambia al modo Teletrabajo solo en las redes Wi-Fi que marques como Teletrabajo abajo (p. ej. tu red doméstica).",
+        "addBtnTitle": "Añadir",
+        "addCurrentBtnTitle": "Usar red actual",
+        "removeBtnTitle": "Eliminar seleccionada",
+        "colSSIDTitle": "Red Wi-Fi (SSID)",
+        "colProfileTitle": "Modo (Teletrabajo / Oficina)",
+        "alertAddTitle": "Añadir asignación de perfil Wi-Fi",
+        "alertAddInfo": "Introduce el nombre de la red Wi-Fi (SSID) y el modo al que cambiar.",
+        "alertSSIDPlaceholder": "Nombre de la red Wi-Fi (SSID)",
+        "alertModeLabel": "Modo:",
+        "alertBtnAdd": "Añadir",
+        "alertBtnCancel": "Cancelar",
+        "alertNotConnectedTitle": "Sin conexión",
+        "alertNotConnectedMessage": "Focus Bear no pudo leer tu red Wi-Fi actual. Asegúrate de que los Servicios de Localización estén activados para Focus Bear.",
+        "permissionWarningText": "⚠️ Se requiere permiso de ubicación para leer el nombre de la red Wi-Fi. Actívalo en Ajustes del Sistema → Privacidad y seguridad → Servicios de Localización."
+    },
+    "eveningShutdownInfo":{
+        "title": "Bien hecho por terminar tu rutina nocturna",
+        "subtitle": "Que descanses bien",
+        "buttonSleepText": "Dormir",
+        "buttonShutDownText": "Apagar",
+        "buttonNotNowText": "Ahora no"
+    },
     "welcomeInfo": {
         "welcomeMessageHeading": "Hagamos una actividad rápida de 30 seg",
         "welcomeMessageIntro": "Todas las mañanas, te ayudaré a silenciar tu impulso de revisar el correo electrónico/Facebook y te ayudaré a hacer tu rutina matutina en su lugar.\n\nTe daré una actividad sugerida: 30 segundos de respiración consciente/estiramento.\n\nMientras respiras profundamente/estiras, piensa en lo increíble que serás si sigues tu rutina matutina todos los días.",
@@ -466,6 +505,7 @@
         "activationErrorSubTitle": "Introduzca una clave de licencia válida."
     },
     "menuInfo": {
+        "menuItemMeetingDetectionBreaksOnTooltip": "Los descansos siguen activos durante esta reunión porque has activado “Mostrar descansos en llamadas”. Puedes desactivarlo en Ajustes si prefieres que no te interrumpan mientras presentas.",
         "menuItemReactivateTitle": "Activar bloqueo de distracciones",
         "menuItemEnterLicenseKeyTitle": "Introduce la clave de la licencia",
         "menuItemPreferencesTitle": "Preferencias",
@@ -560,6 +600,9 @@
         "habitPostponedState": "✋Pospuesto"
     },
     "preferencesInfo": {
+        "checkBoxFocusMusicText": "Reproducir música de enfoque automáticamente al iniciar una sesión",
+        "switchButtonFocusGlowBorderText": "Mostrar borde brillante durante las sesiones de enfoque",
+        "descriptionFocusGlowBorderText": "Muestra un suave borde brillante alrededor de la pantalla mientras se ejecuta una sesión de enfoque.",
         "titlePomodoro": "Modo Pomodoro:",
         "checkBoxPomodoroText": "Entrar en la sesión de Enfoque después de completar la rutina matutina",
         "titleReduceMotion": "Reducir movimiento:",
@@ -1006,6 +1049,7 @@
         "tabViewAccountabilityBuddyTitle": "Compañer@ de responsabilidad"
     },
     "passwordPreferencesInfo": {
+        "buttonPostponeEveningHabitAfterCutOffText": "Posponiendo la rutina nocturna después de la hora límite",
         "titleSetPassword": "Configurar la contraseña",
         "titleChangePassword": "Cambiar Contraseña",
         "newPasswordPlaceholderText": "Nueva Contraseña",
@@ -1092,6 +1136,8 @@
         "buttonSkipMicrobreaksText": "¿Omitir micro-descansos durante bloqueos de trabajo?"
     },
     "accountVcInfo": {
+        "titleLeaderboardUsernameText": "Nombre de usuario en la clasificación:",
+        "leaderboardUsernamePlaceholder": "Sin establecer: actualiza tu nombre de usuario en la clasificación en la aplicación web",
         "title": "Información de tu cuenta",
         "titleNameText": "Nombre:",
         "titleEmailIdText": "Correo electrónico:",
@@ -1645,6 +1691,7 @@
         "buttonDontAskAgainText": "Recordar mi elección"
     },
     "focusMusicInfo": {
+        "nowPlayingLabelText": "Reproduciendo ahora",
         "sectionTitleSpotify": "Spotify",
         "sectionTitleYouTubeMusic": "YouTube Music",
         "sectionTitleLibrary": "Biblioteca de música de enfoque",
@@ -2179,6 +2226,10 @@
         "descriptionBlockUrlsDuringMeetings": "Evita momentos incómodos de compartir pantalla. Desactiva esta opción si no quieres que se produzcan bloqueos durante las reuniones."
     },
     "tooltips": {
+        "accessibility_FocusMusicPrompt": "Activa esto para reproducir música de enfoque automáticamente cada vez que inicies una sesión de enfoque.",
+        "strictness_Password_PostponeMorningHabit": "Activa esto para requerir tu contraseña al posponer tu rutina matutina, para que la decisión siga siendo intencional.",
+        "strictness_Password_PostponeEveningHabit": "Activa esto para requerir tu contraseña al posponer tu rutina nocturna, para que la decisión siga siendo intencional.",
+        "strictness_Password_PostponeEveningHabitAfterCutOffTime": "Activa esto para requerir tu contraseña al posponer tu rutina nocturna después de la hora límite, para que la decisión siga siendo intencional.",
         "ui_ActivitiesFullScreen": "Minimiza las distracciones haciendo tus hábitos en modo pantalla completa para no ver notificaciones ni otras apps mientras haces tus rutinas. Si activas esta opción, no podrás cambiar a otras apps con cmd-tab. Puedes desactivar Focus Bear en caso de emergencia.",
         "ui_ShowDockIcon": "Activa esta opción para mostrar el icono de Focus Bear en tu Dock. Si haces clic en el icono del Dock, se abrirá el menú de Focus Bear.",
         "ui_SelectLanguage": "Hemos traducido la app a algunos idiomas. Elige aquí el idioma que prefieras. Si necesitas otro idioma, escríbenos a support@focusbear.io.",
@@ -2576,6 +2627,8 @@
         "buttonReloadText": "Recargar"
     },
     "taskPlayerVcInfo":{
+        "changeTrackTooltip": "Cambiar música de enfoque",
+        "stopFocusSessionLabel": "Detener sesión de enfoque",
         "toolTipSnapLeft": "Ajustar a la izquierda",
         "toolTipSnapRight": "Ajustar a la derecha",
         "playFocusMusicTooltip": "Reproducir música de enfoque",
@@ -2750,6 +2803,20 @@
         "buttonChangeTiming": "Cambiar horario"
     },
     "scheduleViewInfo":{
+        "showDismissedEvents": "Mostrar eventos descartados",
+        "showEventAgain": "Mostrar este evento de nuevo",
+        "hideEvent": "Ocultar este evento",
+        "dismissRepeatingTitle": "Este es un evento recurrente.",
+        "dismissRepeatingInfo": "¿Quieres ocultar todos los eventos de la serie o solo el de hoy?",
+        "dismissRepeatingJustThisOne": "Solo este",
+        "dismissRepeatingAllSeries": "Todos los eventos de la serie",
+        "dismissRepeatingCancel": "Cancelar",
+        "pastHabitComplete": "Completado",
+        "pastHabitCompleteHint": "Lo hice pero olvidé registrarlo 😅",
+        "tasksDetailsLabel": "Detalles",
+        "tasksImportanceLabel": "Importancia",
+        "tasksImportanceUnset": "Sin establecer",
+        "tasksImportanceTooltip": "Importancia %d (%@)",
         "cancelRoutineTitle": "¿Cancelar rutina?",
         "cancelRoutineMessage": "Si cambias de opinión más tarde, puedes hacer clic en el botón «<BUTTON>» para restaurar la rutina.",
         "cancelRoutineOk": "Aceptar",
@@ -2841,6 +2908,14 @@
         "tabDayPlan": "Plan del día"
     },
     "leftMenuVcInfo":{
+        "menuStats": "Estadísticas",
+        "menuFocusButton": "Botón de enfoque",
+        "menuTimeTracker": "Registro de tiempo",
+        "menuLateNoMore": "Late No More",
+        "restoreHiddenToolsTitle": "Herramientas ocultas",
+        "restoreHiddenToolsEmpty": "Nada oculto: pasa el cursor sobre una herramienta y haz clic en ✕ para ocultarla.",
+        "restoreButton": "Restaurar",
+        "hideToolTooltip": "Ocultar esta herramienta",
         "titleMain": "PRINCIPAL",
         "titleTools": "HERRAMIENTAS",
         "titlePreferences": "PREFERENCIAS",

--- a/config/config.json
+++ b/config/config.json
@@ -1,4 +1,43 @@
 {
+    "focusButtonInfo":{
+        "focusSessionEmoji": "Focus session emoji",
+        "focusEmojiHint": "Pick up to 5 emoji — the button shows a random one as the hero when you start a focus session.",
+        "save": "Save",
+        "habitIconsLabel": "Habit icons",
+        "focusIconsLabel": "Focus session icons",
+        "iconsUpToDate": "up to date",
+        "checkingHabitIcons": "Checking habit icons…",
+        "checkingFocusIcons": "Checking focus icons…"
+    },
+    "officeModeSettingsVcInfo":{
+        "settingTitle": "Office Mode",
+        "descriptionText": "During office mode, Focus Bear will only give you office friendly break habits (e.g. stretching vs pushups).",
+        "officeModeOptionText": "Office Mode",
+        "wfhModeOptionText": "WFH Mode",
+        "autoSwitchSectionTitle": "Switch automatically using Wi-Fi networks",
+        "autoSwitchDescription": "Focus Bear defaults to Office mode and switches to WFH mode only on the Wi-Fi networks you mark as WFH below (e.g. your home network).",
+        "addBtnTitle": "Add",
+        "addCurrentBtnTitle": "Use Current Network",
+        "removeBtnTitle": "Remove Selected",
+        "colSSIDTitle": "Wi-Fi Network (SSID)",
+        "colProfileTitle": "Mode (WFH / Office)",
+        "alertAddTitle": "Add Wi-Fi Profile Mapping",
+        "alertAddInfo": "Enter the Wi-Fi network name (SSID) and the mode to switch to.",
+        "alertSSIDPlaceholder": "Wi-Fi network name (SSID)",
+        "alertModeLabel": "Mode:",
+        "alertBtnAdd": "Add",
+        "alertBtnCancel": "Cancel",
+        "alertNotConnectedTitle": "Not Connected",
+        "alertNotConnectedMessage": "Focus Bear couldn't read your current Wi-Fi network. Make sure Location Services are enabled for Focus Bear.",
+        "permissionWarningText": "⚠️ Location permission required to read Wi-Fi network name. Enable it in System Settings → Privacy & Security → Location Services."
+    },
+    "eveningShutdownInfo":{
+        "title": "Well done on finishing your evening routine",
+        "subtitle": "Have a restful sleep",
+        "buttonSleepText": "Sleep",
+        "buttonShutDownText": "Shut Down",
+        "buttonNotNowText": "Not now"
+    },
     "welcomeInfo": {
         "welcomeMessageHeading": "Let’s do a quick 30 seconds microbreak",
         "welcomeMessageIntro": "Every morning, I will help you silence your urge to check email/Facebook and help you to do your morning routine instead.\n\nLet’s try out some sample habits (deep breathing/stretching).\n\nWhile you breathe deeply/stretch, think of how awesome you’ll be if you stick to your morning routine every day.",
@@ -454,6 +493,7 @@
         "activationErrorSubTitle": "Please enter a valid License key."
     },
     "menuInfo": {
+        "menuItemMeetingDetectionBreaksOnTooltip": "Breaks are still on during this meeting because you've turned on \"Show breaks in call\". You can turn that off in Settings if you'd rather not be interrupted while presenting.",
         "menuItemReactivateTitle": "Activate Distraction Blocking",
         "menuItemEnterLicenseKeyTitle": "Enter License Key",
         "menuItemPreferencesTitle": "Preferences",
@@ -548,6 +588,9 @@
         "habitPostponedState": "✋Postponed"
     },
     "preferencesInfo": {
+        "checkBoxFocusMusicText": "Automatically play focus music when a session starts",
+        "switchButtonFocusGlowBorderText": "Show glow border during focus sessions",
+        "descriptionFocusGlowBorderText": "Display a soft glowing border around your screen while a focus session is running.",
         "titlePomodoro": "Pomodoro Mode:",
         "checkBoxPomodoroText": "Enter Focus session after completing morning routine",
         "titleReduceMotion": "Reduce motion:",
@@ -1006,6 +1049,7 @@
         "tabViewAccountabilityBuddyTitle": "Accountability Buddy"
     },
     "passwordPreferencesInfo": {
+        "buttonPostponeEveningHabitAfterCutOffText": "Postponing evening routine after cutoff time",
         "titleSetPassword": "Set Password",
         "titleChangePassword": "Change Password",
         "newPasswordPlaceholderText": "New Password",
@@ -1092,6 +1136,8 @@
         "buttonSkipMicrobreaksText": "Skip microbreaks during work blocks?"
     },
     "accountVcInfo": {
+        "titleLeaderboardUsernameText": "Leaderboard Username:",
+        "leaderboardUsernamePlaceholder": "Not set — update your leaderboard username in the web app",
         "title": "Your Account Information",
         "titleNameText": "Name:",
         "titleEmailIdText": "Email Id:",
@@ -1646,6 +1692,7 @@
         "buttonDontAskAgainText": "Remember my choice"
     },
     "focusMusicInfo": {
+        "nowPlayingLabelText": "Now Playing",
         "sectionTitleSpotify": "Spotify",
         "sectionTitleYouTubeMusic": "YouTube Music",
         "sectionTitleLibrary": "Focus Music Library",
@@ -2181,6 +2228,10 @@
         "descriptionBlockUrlsDuringMeetings": "Avoid awkward screensharing moments. Turn this setting off if you don’t want blocking to happen while you’re in meetings."
     },
     "tooltips": {
+        "accessibility_FocusMusicPrompt": "Turn this on to automatically play focus music whenever you start a focus session.",
+        "strictness_Password_PostponeMorningHabit": "Enable this to require your password when postponing your morning routine, so the choice stays intentional.",
+        "strictness_Password_PostponeEveningHabit": "Enable this to require your password when postponing your evening routine, so the choice stays intentional.",
+        "strictness_Password_PostponeEveningHabitAfterCutOffTime": "Enable this to require your password when postponing your evening routine after the cutoff time, so the choice stays intentional.",
         "ui_ActivitiesFullScreen": "Minimize distractions by doing your habits in full screen mode so you can’t see notifications or other apps while you’re doing your routines. If you enable this setting, you won’t be able to switch to other apps via cmd-tab. You can still deactivate Focus Bear if you have an emergency.",
         "ui_ShowDockIcon": "Enable this setting to show the Focus Bear app icon in your Dock. If you click on the dock icon, it will open the Focus Bear menu.",
         "ui_SelectLanguage": "We’ve translated the app into a few languages. Choose your preferred language here. Let us know if you need a different language by emailing support@focusbear.io",
@@ -2578,6 +2629,8 @@
         "buttonReloadText": "Reload"
     },
     "taskPlayerVcInfo":{
+        "changeTrackTooltip": "Change focus music",
+        "stopFocusSessionLabel": "Stop focus session",
         "toolTipSnapLeft": "Snap to left",
         "toolTipSnapRight": "Snap to right",
         "playFocusMusicTooltip": "Play focus music",
@@ -2752,6 +2805,20 @@
         "buttonChangeTiming": "Change Timing"
     },
     "scheduleViewInfo":{
+        "showDismissedEvents": "Show dismissed events",
+        "showEventAgain": "Show this event again",
+        "hideEvent": "Hide this event",
+        "dismissRepeatingTitle": "This is a repeating event.",
+        "dismissRepeatingInfo": "Would you like to hide all events in the series or just the one for today?",
+        "dismissRepeatingJustThisOne": "Just this one",
+        "dismissRepeatingAllSeries": "All events in series",
+        "dismissRepeatingCancel": "Cancel",
+        "pastHabitComplete": "Complete",
+        "pastHabitCompleteHint": "I actually did it but forgot to log it 😅",
+        "tasksDetailsLabel": "Details",
+        "tasksImportanceLabel": "Importance",
+        "tasksImportanceUnset": "Not set",
+        "tasksImportanceTooltip": "Importance %d (%@)",
         "cancelRoutineTitle": "Cancel Routine?",
         "cancelRoutineMessage": "If you change your mind later, you can click the \"<BUTTON>\" button to restore the routine.",
         "cancelRoutineOk": "OK",
@@ -2843,6 +2910,14 @@
         "tabDayPlan": "Day Plan"
     },
     "leftMenuVcInfo":{
+        "menuStats": "Stats",
+        "menuFocusButton": "Focus Button",
+        "menuTimeTracker": "Time Tracker",
+        "menuLateNoMore": "Late No More",
+        "restoreHiddenToolsTitle": "Hidden tools",
+        "restoreHiddenToolsEmpty": "Nothing hidden — hover a tool and click ✕ to hide it.",
+        "restoreButton": "Restore",
+        "hideToolTooltip": "Hide this tool",
         "titleMain": "MAIN",
         "titleTools": "TOOLS",
         "titlePreferences": "PREFERENCES",

--- a/config/config.json
+++ b/config/config.json
@@ -1,4 +1,17 @@
 {
+    "talkingClockSettingsInfo":{
+        "title": "Talking Clock",
+        "back": "Back",
+        "enableTitle": "Enable talking clock",
+        "enableSubtitle": "Announce the current time at regular intervals to help you stay time-aware.",
+        "announceEvery": "Announce every",
+        "minutes": "minutes",
+        "quietHours": "Quiet hours (no announcements between these times)",
+        "start": "Start:",
+        "end": "End:",
+        "suppressTitle": "Suppress during meetings",
+        "suppressSubtitle": "Don't announce the time when you're in a meeting focus mode."
+    },
     "focusButtonInfo":{
         "focusSessionEmoji": "Focus session emoji",
         "focusEmojiHint": "Pick up to 5 emoji — the button shows a random one as the hero when you start a focus session.",

--- a/config/config.json
+++ b/config/config.json
@@ -1639,6 +1639,25 @@
         "titleVolumeText": "Volume:",
         "downloadButtonText": "Download"
     },
+    "focusMusicPromptInfo": {
+        "title": "Want to play some focus music?",
+        "buttonYesText": "Yes, play music",
+        "buttonNoText": "No thanks",
+        "buttonDontAskAgainText": "Remember my choice"
+    },
+    "focusMusicInfo": {
+        "sectionTitleSpotify": "Spotify",
+        "sectionTitleYouTubeMusic": "YouTube Music",
+        "sectionTitleLibrary": "Focus Music Library",
+        "spotifyAddPlaceholder": "Paste a Spotify track/album/playlist link",
+        "youtubeAddPlaceholder": "Paste a music.youtube.com link",
+        "addButtonText": "Add",
+        "youtubeHintText": "Add a music.youtube.com video or playlist link to play it here.",
+        "addOwnMusicButtonText": "Add my own music",
+        "spotifyInvalidLinkError": "That doesn't look like a Spotify track/album/playlist link.",
+        "spotifyNotInstalledError": "Spotify isn't installed on this Mac.",
+        "youtubeInvalidLinkError": "That doesn't look like a music.youtube.com link."
+    },
     "setUpVcInfo": {
         "title": "Setup",
         "customiseFocusModeText": "Customise a focus mode",


### PR DESCRIPTION
## Summary
Companion strings PR for two Mac-App PRs that have been shipping against English fallback strings baked into the Swift code, since these config keys didn't exist here yet:

- [Mac-App#2086](https://github.com/Focus-Bear/Mac-App/pull/2086) — Spotify + YouTube Music (music.youtube.com only) links in the Focus Music screen (`focusMusicInfo`)
- [Mac-App#2088](https://github.com/Focus-Bear/Mac-App/pull/2088) — the post-session-start "Want to play some focus music?" prompt (`focusMusicPromptInfo`)

Adds both blocks to `config/config.json` (English) and `config/config-es.json` (Spanish), placed right after the existing `allTracksVcInfo` block (the Focus Music screen's existing i18n block) in both files.

## Test plan
- [x] Both JSON files parse (`python3 -c "import json; json.load(open(...))"`)
- [ ] Confirm the Mac app picks these up correctly once merged (the Swift-side fallback strings already match these values exactly, so behavior shouldn't visibly change in English — only Spanish locale users should see the difference).

---

## Update: full config audit folded in

Also ran a complete audit of Mac-App `FocusBear/config.json` vs this repo and added **every** user-facing string that was missing here (69 keys) in both English and Spanish, so Spanish users stop getting English fallbacks. (Supersedes standalone PR #371, now closed.)

New blocks added: `eveningShutdownInfo`, `officeModeSettingsVcInfo`, `focusButtonInfo`.
Keys added into existing blocks: `menuInfo`, `preferencesInfo`, `passwordPreferencesInfo`, `accountVcInfo`, `focusMusicInfo` (nowPlayingLabelText), `tooltips`, `taskPlayerVcInfo`, `scheduleViewInfo`, `leftMenuVcInfo`.

Both files parse; pure additions (formatting preserved).