### PR TITLE
config: focusButtonInfo + Day Plan dismissed-events strings (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2765,6 +2765,9 @@
         "eventSave": "Guardar",
         "eventCancel": "Cancelar",
         "eventSaveError": "No se pudo guardar el evento. Comprueba el acceso al calendario e inténtalo de nuevo.",
+        "showDismissedEvents": "Mostrar eventos descartados",
+        "showEventAgain": "Volver a mostrar este evento",
+        "hideEvent": "Ocultar este evento",
         "showEarlierEvents": "Mostrar eventos anteriores de hoy",
         "hideEarlierEvents": "Ocultar eventos anteriores de hoy",
         "viewTomorrow": "Ver el horario de mañana",
@@ -3109,5 +3112,15 @@
         "downloadingUpdate": "Descargando Actualización",
         "downloadProgress": "Descargando Actualización: {0} de {1}",
         "allWebsitesAllowed": "Todos los sitios web están permitidos"
+    },
+    "focusButtonInfo":{
+        "focusSessionEmoji": "Emoji de la sesión de concentración",
+        "focusEmojiHint": "Elige hasta 5 emojis: el botón muestra uno al azar como protagonista cuando inicias una sesión de concentración.",
+        "save": "Guardar",
+        "habitIconsLabel": "Iconos de hábitos",
+        "focusIconsLabel": "Iconos de la sesión de concentración",
+        "iconsUpToDate": "actualizados",
+        "checkingHabitIcons": "Comprobando iconos de hábitos…",
+        "checkingFocusIcons": "Comprobando iconos de concentración…"
     }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -2767,6 +2767,9 @@
         "eventSave": "Save",
         "eventCancel": "Cancel",
         "eventSaveError": "Couldn't save the event. Check calendar access and try again.",
+        "showDismissedEvents": "Show dismissed events",
+        "showEventAgain": "Show this event again",
+        "hideEvent": "Hide this event",
         "showEarlierEvents": "Show events from earlier today",
         "hideEarlierEvents": "Hide events from earlier today",
         "viewTomorrow": "View tomorrow's schedule",
@@ -3111,5 +3114,15 @@
         "downloadingUpdate": "Downloading Update",
         "downloadProgress": "Downloading Update: {0} of {1}",
         "allWebsitesAllowed": "All websites are allowed"
+    },
+    "focusButtonInfo":{
+        "focusSessionEmoji": "Focus session emoji",
+        "focusEmojiHint": "Pick up to 5 emoji — the button shows a random one as the hero when you start a focus session.",
+        "save": "Save",
+        "habitIconsLabel": "Habit icons",
+        "focusIconsLabel": "Focus session icons",
+        "iconsUpToDate": "up to date",
+        "checkingHabitIcons": "Checking habit icons…",
+        "checkingFocusIcons": "Checking focus icons…"
     }
 }


### PR DESCRIPTION
## Summary
Adds the new Mac-app user-facing strings to `config.json` (EN) + `config-es.json` (ES):

- **focusButtonInfo** (Focus Button tool screen): focus-session emoji picker label/hint/Save, and the habit-icon vs focus-icon sync status labels.
- **scheduleViewInfo**: `showDismissedEvents` (Day Plan settings toggle), `showEventAgain` / `hideEvent` (meeting ✕/👀 tooltips).

Pairs with Mac-App #2044 (Focus Button emoji) and #2049 (Show dismissed events) — the app falls back to English for these keys until this merges.

## Replaces #361
That PR turned out not to be the minimal diff its description claimed. On inspection its branch was generated from Mac-App's own local `config.json`/`config-es.json` copies, which had already drifted out of sync with `assets/main` — so alongside the two intended blocks it also:
- **Corrupted `appAppearanceOptions`** in both files — merged `"Never Dark Mode"` and `"Automatically"` into a single string (`"Never Dark Mode, Automatically"`), which `uIVc.swift` reads straight into the Dark Mode dropdown. Would've broken that setting for every locale.
- **Deleted ~30 Spanish translation keys** for the Day Plan Tasks panel (`tasksSnoozeHelp`, `tasksAddNew`, `tasksProjectField`, `customRoutinesTitle`, `tabDayPlan`, etc.) that exist correctly on `main` today — Spanish users would've lost those translations and fallen back to English.
- Silently dropped a handful of other keys not mentioned in its description (confirmed unused in Mac-App's current code, so likely harmless, but undocumented).

This branch starts fresh from `main` and only adds the two intended blocks — **26 insertions, 0 deletions**, both files re-validated as JSON.

## Test plan
- [x] Both files parse (`python3 -c "import json; json.load(open(...))"`)
- [x] Diff contains only the two new blocks — no unrelated deletions or reordering
- [ ] Confirm the Mac app picks these up correctly once merged (Focus Button emoji screen, Day Plan dismissed-events toggle/tooltips) in both English and Spanish