### PR TITLE
i18n(todo-player): stopFocusSessionLabel + changeTrackTooltip (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2566,7 +2566,9 @@
         "toolTipSnapLeft": "Ajustar a la izquierda",
         "toolTipSnapRight": "Ajustar a la derecha",
         "playFocusMusicTooltip": "Reproducir música de enfoque",
-        "endFocusSessionTooltip": "Finalizar sesión de enfoque"
+        "endFocusSessionTooltip": "Finalizar sesión de enfoque",
+        "changeTrackTooltip": "Cambiar música de enfoque",
+        "stopFocusSessionLabel": "Detener sesión de enfoque"
     },
     "onboardingBlockingScheduleVcInfo":{
         "title": "Horario de Bloqueo",

--- a/config/config.json
+++ b/config/config.json
@@ -2568,7 +2568,9 @@
         "toolTipSnapLeft": "Snap to left",
         "toolTipSnapRight": "Snap to right",
         "playFocusMusicTooltip": "Play focus music",
-        "endFocusSessionTooltip": "End focus session"
+        "endFocusSessionTooltip": "End focus session",
+        "changeTrackTooltip": "Change focus music",
+        "stopFocusSessionLabel": "Stop focus session"
     },
     "onboardingBlockingScheduleVcInfo":{
         "title": "Blocking Schedule",


### PR DESCRIPTION
Companion assets PR for **Mac-App #2113** (To Do Player now-playing bar).

Adds two new `taskPlayerVcInfo` strings the SwiftUI top bar reads, in **both** `config/config.json` (English) and `config/config-es.json` (Spanish):

| key | EN | ES |
|-----|----|----|
| `stopFocusSessionLabel` | Stop focus session | Detener sesión de enfoque |
| `changeTrackTooltip` | Change focus music | Cambiar música de enfoque |

The Mac app has English fallbacks baked in so it works before this lands, but Spanish users need this PR to see translated text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)