### PR TITLE
Add shortcuts strings for keyboard shortcut feature 

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -685,6 +685,8 @@
         "checkBoxFullScreenEnabledText": "Reproducir hábitos en modo pantalla completa",
         "checkBoxAutoCloseAfterRoutineText": "Cerrar ventana automáticamente al completar, omitir o posponer una rutina",
         "titleDarkMode": "Modo Oscuro:",
+        "titleEnableShortCuts": "Habilitar/Deshabilitar accesos directos",
+        "titleBrainDumpShortcut": "Acceso directo para abrir el volcado de ideas:",
         "appAppearanceOptions": ["Copiar Preferencias del Sistema", "Siempre en Modo Oscuro", "Nunca en Modo Oscuro", "Automáticamente"],
         "titleAnnouncement": "Anuncio:",
         "checkBoxAnnouncementText": "Anuncio después de cada actividad",
@@ -2299,7 +2301,8 @@
         "breaks_NaturalBreaks": "Te avisa cuando se detecta una pausa natural tras estar inactivo por más de 10 minutos, ayudándote a mantener el enfoque y la productividad.",
         "strictness_Block_Lists": "Usa las listas de bloqueo para mantenerte enfocad@ en un tipo de trabajo. Inicia una sesión de enfoque desde el menú de Focus Bear o crea un horario de bloqueo.",
         "strictness_Blocking_Schedules": "Crea tus propios horarios para bloquear distracciones automáticamente. Elige los días y horas en que quieres que se bloqueen las distracciones. Mantente enfocad@ sin tener que activar el bloqueo manualmente.",
-        "strictness_AlwaysAllowedApps": "Las apps que añadas aquí nunca se bloquearán, sin importar el modo de enfoque, los horarios de bloqueo o el nivel de restricción. Úsalo para apps esenciales a las que siempre necesitas acceder."
+        "strictness_AlwaysAllowedApps": "Las apps que añadas aquí nunca se bloquearán, sin importar el modo de enfoque, los horarios de bloqueo o el nivel de restricción. Úsalo para apps esenciales a las que siempre necesitas acceder.",
+        "shortcutsToggleInfo": "Activar o desactivar atajos por ventana"
     },
     "chooseHabitsVCInfo": {
         "title": "Elegir Hábitos:",

--- a/config/config.json
+++ b/config/config.json
@@ -673,6 +673,8 @@
     	"checkBoxFullScreenEnabledText": "Play habits in full screen mode",
         "checkBoxAutoCloseAfterRoutineText": "Automatically close window after completing, skipping or postponing a routine",
         "titleDarkMode": "Dark Mode:",
+        "titleEnableShortCuts": "Enable/Disable shortcuts",
+        "titleBrainDumpShortcut": "Shortcut to open brain dump:",
         "appAppearanceOptions": ["Copy system preferences", "Always Dark Mode", "Never Dark Mode", "Automatically"],
         "titleAnnouncement": "Announcement:",
         "checkBoxAnnouncementText": "Announcement after each activity",
@@ -2301,7 +2303,8 @@
         "breaks_NaturalBreaks": "Notifies you when a natural break is detected after being idle for more than 10 minutes, helping you maintain focus and productivity.",
         "strictness_Block_Lists": "Use Block Lists to stay focused on a certain type of work. Start a focus session from the focus bear menu or use a blocking schedule.",
         "strictness_Blocking_Schedules": "Create your own schedules to automatically block distractions. Pick the days and times when distractions should be blocked. Stay focused without needing to start blocking manually.",
-        "strictness_AlwaysAllowedApps": "Apps added here will never be blocked, regardless of focus mode, blocking schedules, or strictness settings. Use this for essential apps that you always need access to."
+        "strictness_AlwaysAllowedApps": "Apps added here will never be blocked, regardless of focus mode, blocking schedules, or strictness settings. Use this for essential apps that you always need access to.",
+        "shortcutsToggleInfo": "Enable or disable shortcuts per window"
     },
     "chooseHabitsVCInfo": {
         "title": "Choose Habits:",


### PR DESCRIPTION
Adding the strings needed for the new shortcuts toggle in Windows Preferences > UI.

- titleEnableShortCuts / titleBrainDumpShortcut (preferencesInfo)
- shortcutsToggleInfo (tooltips)

Added in both config.json and config-es.json. Related PR: Focus-Bear/windows-app-v2#1150