### PR TITLE
i18n: reword activities sync-error notification

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -215,7 +215,7 @@
         "graphDateText": "Fecha",
         "graphTimeText": "Tiempo",
         "buttonBackToMyHabitsText": "Regresar a mis hábitos",
-        "activitiesSyncErrorText": "Focus Bear no ha podido sincronizar las estadísticas de las actividades debido a mala conexión de internet.",
+        "activitiesSyncErrorText": "Problema de conexión: la finalización de hábitos se sincronizará cuando tu conexión se estabilice.",
         "alertAppRestartText": "Focus Bear se reinicia automáticamente si se cierra o bloquea a la fuerza para asegurarse de ayudarte a combatir las distracciones. Si quieres salir de la aplicación o tomar un descanso, usa las funciones para salir en la barra de menú de Focus Bear.",
         "buttonDontTellAgainText": "Entendido – No mencionar de nuevo",
         "toolTipColorBoxText": "Elige un color para que se muestre en el fondo del ícono de la barra de menú superior para ayudar a identificar el modo de enfoque que estás ejecutando.",

--- a/config/config.json
+++ b/config/config.json
@@ -215,7 +215,7 @@
         "graphDateText": "Date",
         "graphTimeText": "Time",
         "buttonBackToMyHabitsText": "Back to my habits",
-        "activitiesSyncErrorText": "Focus Bear was not able to sync the activities' statistics due to bad internet.",
+        "activitiesSyncErrorText": "Internet issue: habit completion will sync once your connection stabilises.",
         "alertAppRestartText": "Focus Bear automatically restarts if it gets force quit/crashes to make sure you always have help combatting distractions. If you want to quit the app/take a break, use the Quit option from the Focus Bear menu bar.",
         "buttonDontTellAgainText": "Got it - don't tell me again",
         "toolTipColorBoxText": "Choose a color to be displayed in the background of the top menu bar icon to help identify the Focus Mode you are running.",


### PR DESCRIPTION
Reword the `common.activitiesSyncErrorText` notification (en + es) to describe the outcome rather than blaming the connection.

- **Before:** "Focus Bear was not able to sync the activities' statistics due to bad internet."
- **After:** "Internet issue: habit completion will sync once your connection stabilises."
- **es:** "Problema de conexión: la finalización de hábitos se sincronizará cuando tu conexión se estabilice."

Companion to the Mac-App PR (`fix/sync-error-copy`), which updates `FocusBear/config.json` and the two hardcoded fallbacks in `AllApi.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)