### PR TITLE
i18n: add menu focus-music play/pause tooltips

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2960,6 +2960,8 @@
         "menuTodoList": "Lista de tareas",
         "menuBrainDump": "Volcado de ideas",
         "menuFocusMusic": "Música de enfoque",
+        "menuPlayMusic": "Reproducir música",
+        "menuPauseMusic": "Pausar música",
         "menuFocusPreferences": "Enfoque",
         "menuBlocksPreferences": "Bloqueo",
         "menuSettings": "Ajustes",

--- a/config/config.json
+++ b/config/config.json
@@ -2962,6 +2962,8 @@
         "menuTodoList": "Todo List",
         "menuBrainDump": "Brain Dump",
         "menuFocusMusic": "Focus Music",
+        "menuPlayMusic": "Play music",
+        "menuPauseMusic": "Pause music",
         "menuFocusPreferences": "Focus",
         "menuBlocksPreferences": "Blocking",
         "menuSettings": "Settings",


### PR DESCRIPTION
Adds two `leftMenuVcInfo` keys (en + es) for the menu popup's new top-level focus-music control:

| key | en | es |
|-----|-----|-----|
| `menuPlayMusic` | Play music | Reproducir música |
| `menuPauseMusic` | Pause music | Pausar música |

Companion to Mac-App PR #2134 (Focus-Bear/Mac-App#2134). The Mac `config-assets-sync` CI check (which reads assets `main`) fails until these land here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)