### PR TITLE
i18n: add focusIconsSyncIncomplete (en + es)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -3279,6 +3279,7 @@
         "focusIconsLabel": "Iconos de la sesión de concentración",
         "iconsUpToDate": "actualizados",
         "checkingHabitIcons": "Comprobando iconos de hábitos…",
-        "checkingFocusIcons": "Comprobando iconos de concentración…"
+        "checkingFocusIcons": "Comprobando iconos de concentración…",
+        "focusIconsSyncIncomplete": "⚠️ No se pudieron sincronizar todos los iconos de enfoque — inténtalo de nuevo"
     }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -3281,6 +3281,7 @@
         "focusIconsLabel": "Focus session icons",
         "iconsUpToDate": "up to date",
         "checkingHabitIcons": "Checking habit icons…",
-        "checkingFocusIcons": "Checking focus icons…"
+        "checkingFocusIcons": "Checking focus icons…",
+        "focusIconsSyncIncomplete": "⚠️ Couldn't sync all focus icons — try again"
     }
 }


### PR DESCRIPTION
Companion to Mac-App #2143. Adds `focusButtonInfo.focusIconsSyncIncomplete` so the focus-icon sync can show a terminal 'couldn't sync all focus icons' message instead of a spinner that hangs forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)