### PR TITLE
i18n: add day-plan create-new-project keys (en + es)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2910,6 +2910,8 @@
         "tasksShowCompleted": "Mostrar completadas",
         "tasksShowCompletedCount": "Mostrar completadas (%d)",
         "tasksExpand": "Expandir",
+        "tasksNewProjectPrompt": "Crear nuevo proyecto:",
+        "tasksNewProjectSave": "Guardar",
         "tasksSnooze": "Posponer",
         "tasksRemove": "Eliminar",
         "tasksDetailsTitle": "Detalles de la tarea",

--- a/config/config.json
+++ b/config/config.json
@@ -2912,6 +2912,8 @@
         "tasksShowCompleted": "Show completed",
         "tasksShowCompletedCount": "Show completed (%d)",
         "tasksExpand": "Expand",
+        "tasksNewProjectPrompt": "Create new project:",
+        "tasksNewProjectSave": "Save",
         "tasksSnooze": "Snooze",
         "tasksRemove": "Remove",
         "tasksDetailsTitle": "Task details",


### PR DESCRIPTION
Adds `scheduleViewInfo.tasksNewProjectPrompt` / `tasksNewProjectSave` (en + es). These were accidentally pushed to the already-merged #373 branch and never reached main, so Mac-App #2120's config-strings check fails without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)