### PR TITLE
i18n(focus-button): add focusIconsSyncIncomplete + dedupe focusButtonInfo

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -20,7 +20,8 @@
         "focusIconsLabel": "Iconos de sesión de enfoque",
         "iconsUpToDate": "actualizado",
         "checkingHabitIcons": "Comprobando iconos de hábitos…",
-        "checkingFocusIcons": "Comprobando iconos de enfoque…"
+        "checkingFocusIcons": "Comprobando iconos de enfoque…",
+        "focusIconsSyncIncomplete": "⚠️ No se pudieron sincronizar todos los iconos de enfoque — inténtalo de nuevo"
     },
     "officeModeSettingsVcInfo":{
         "settingTitle": "Modo oficina",
@@ -3345,15 +3346,5 @@
         "downloadingUpdate": "Descargando Actualización",
         "downloadProgress": "Descargando Actualización: {0} de {1}",
         "allWebsitesAllowed": "Todos los sitios web están permitidos"
-    },
-    "focusButtonInfo":{
-        "focusSessionEmoji": "Emoji de la sesión de concentración",
-        "focusEmojiHint": "Elige hasta 5 emojis: el botón muestra uno al azar como protagonista cuando inicias una sesión de concentración.",
-        "save": "Guardar",
-        "habitIconsLabel": "Iconos de hábitos",
-        "focusIconsLabel": "Iconos de la sesión de concentración",
-        "iconsUpToDate": "actualizados",
-        "checkingHabitIcons": "Comprobando iconos de hábitos…",
-        "checkingFocusIcons": "Comprobando iconos de concentración…"
     }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -20,7 +20,8 @@
         "focusIconsLabel": "Focus session icons",
         "iconsUpToDate": "up to date",
         "checkingHabitIcons": "Checking habit icons…",
-        "checkingFocusIcons": "Checking focus icons…"
+        "checkingFocusIcons": "Checking focus icons…",
+        "focusIconsSyncIncomplete": "⚠️ Couldn't sync all focus icons — try again"
     },
     "officeModeSettingsVcInfo":{
         "settingTitle": "Office Mode",
@@ -3347,15 +3348,5 @@
         "downloadingUpdate": "Downloading Update",
         "downloadProgress": "Downloading Update: {0} of {1}",
         "allWebsitesAllowed": "All websites are allowed"
-    },
-    "focusButtonInfo":{
-        "focusSessionEmoji": "Focus session emoji",
-        "focusEmojiHint": "Pick up to 5 emoji — the button shows a random one as the hero when you start a focus session.",
-        "save": "Save",
-        "habitIconsLabel": "Habit icons",
-        "focusIconsLabel": "Focus session icons",
-        "iconsUpToDate": "up to date",
-        "checkingHabitIcons": "Checking habit icons…",
-        "checkingFocusIcons": "Checking focus icons…"
     }
 }


### PR DESCRIPTION
Adds the new focus-icon **sync-incomplete** string (EN + ES) required by Mac App PR #2143 (fixes the failing *"Local config strings exist in assets repo"* check), and resolves a pre-existing duplicate.

## Changes
- **`focusButtonInfo.focusIconsSyncIncomplete`** added:
  - EN: `⚠️ Couldn't sync all focus icons — try again`
  - ES: `⚠️ No se pudieron sincronizar todos los iconos de enfoque — inténtalo de nuevo`
- **Deduped `focusButtonInfo`** — it appeared **twice** in both `config.json` and `config-es.json` (duplicate key → last-wins). Kept the in-context block, removed the trailing duplicate.
  - In ES the two copies disagreed ("enfoque" vs "concentración"); kept **"enfoque"**, consistent with the app's other Focus strings (e.g. keyboard shortcuts) and the Mac local `config-es.json`.

## Why
Mac App PR #2143 (focus-icon sync spinner hang fix) adds `focusIconsSyncIncomplete` locally; the Config↔Assets sync check fails until this lands + publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)