### PR TITLE
i18n(dayplan): add tasksNewProjectPrompt + tasksNewProjectSave

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2911,6 +2911,8 @@
         "tasksShowCompleted": "Mostrar completadas",
         "tasksShowCompletedCount": "Mostrar completadas (%d)",
         "tasksExpand": "Expandir",
+        "tasksNewProjectPrompt": "Crear nuevo proyecto:",
+        "tasksNewProjectSave": "Guardar",
         "tasksSnooze": "Posponer",
         "tasksRemove": "Eliminar",
         "tasksDetailsTitle": "Detalles de la tarea",

--- a/config/config.json
+++ b/config/config.json
@@ -2913,6 +2913,8 @@
         "tasksShowCompleted": "Show completed",
         "tasksShowCompletedCount": "Show completed (%d)",
         "tasksExpand": "Expand",
+        "tasksNewProjectPrompt": "Create new project:",
+        "tasksNewProjectSave": "Save",
         "tasksSnooze": "Snooze",
         "tasksRemove": "Remove",
         "tasksDetailsTitle": "Task details",


### PR DESCRIPTION
Adds the two new Day Plan strings required by Mac App PR #2120 (the "create new project" prompt in the `#project` autocomplete), so the Config↔Assets sync check on that PR passes.

- `scheduleViewInfo.tasksNewProjectPrompt` — EN: `Create new project:` · ES: `Crear nuevo proyecto:`
- `scheduleViewInfo.tasksNewProjectSave` — EN: `Save` · ES: `Guardar`

The reworded snooze strings (`tasksSnoozePlaceholder` / `tasksSnoozeHelp`, incl. the `-1d`/"ayer" back-date wording) are already in this repo, so no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)