### PR TITLE
i18n(breaks): add breakFrequencyVcInfo strings

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -1206,6 +1206,13 @@
         "buttonDontHaveTimeText": "No tengo tiempo",
         "buttonInTheOffIceText": "Estoy en la oficina"
     },
+    "breakFrequencyVcInfo": {
+        "title": "¿Quieres que los descansos sean menos frecuentes?",
+        "currentFrequencyText": "Tu frecuencia de descanso actual es cada %d minutos",
+        "buttonChangeText": "Cambiar frecuencia de descanso",
+        "buttonKeepText": "Dejar como está",
+        "newFrequencyLabel": "Nueva frecuencia (min):"
+    },
     "brainDumpVcInfo": {
         "title": "Focus Bear - Volcado de cerebros",
         "titleIntentionText": "Intención de bloque de enfoque:",

--- a/config/config.json
+++ b/config/config.json
@@ -1206,6 +1206,13 @@
         "buttonDontHaveTimeText": "I don't have time",
         "buttonInTheOffIceText": "I'm in the offIce"
     },
+    "breakFrequencyVcInfo": {
+        "title": "Want to make breaks less frequent?",
+        "currentFrequencyText": "Your current break frequency is every %d minutes",
+        "buttonChangeText": "Change Break Frequency",
+        "buttonKeepText": "Keep as is",
+        "newFrequencyLabel": "New frequency (min):"
+    },
     "brainDumpVcInfo": {
         "title": "Focus Bear - Brain dump",
         "titleIntentionText": "Focus Block intention:",


### PR DESCRIPTION
Adds the `breakFrequencyVcInfo` block required by Mac App PR #1846 — the break-frequency prompt (#1744) was moved off hardcoded Swift strings into `config.json`, so these keys must exist here for the Config↔Assets sync check on that PR to pass.

- **EN** (`config/config.json`) and **ES** (`config/config-es.json`): `title`, `currentFrequencyText` (uses `%d` for the minutes count), `buttonChangeText`, `buttonKeepText`, `newFrequencyLabel`.

Valid JSON; inserted before `brainDumpVcInfo` to match the Mac config order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)