### PR TITLE
Add menuPauseSession / menuResumeSession strings (Mac #2148)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2988,6 +2988,8 @@
         "menuPause": "Pausar",
         "menuResume": "Reanudar",
         "menuStopSession": "Detener sesión",
+        "menuPauseSession": "Pausar sesión",
+        "menuResumeSession": "Reanudar sesión",
         "menuSessionRunning": "Sesión en curso",
         "menuRemaining": "restante",
         "menuFocusedToday": "Enfocado hoy",

--- a/config/config.json
+++ b/config/config.json
@@ -2990,6 +2990,8 @@
         "menuPause": "Pause",
         "menuResume": "Resume",
         "menuStopSession": "Stop session",
+        "menuPauseSession": "Pause session",
+        "menuResumeSession": "Resume session",
         "menuSessionRunning": "Session running",
         "menuRemaining": "remaining",
         "menuFocusedToday": "Focused today",


### PR DESCRIPTION
### What
Adds two new keys to the `menuView` block in both `config/config.json` (EN) and `config/config-es.json` (ES):

- `menuPauseSession` — EN "Pause session" / ES "Pausar sesión"
- `menuResumeSession` — EN "Resume session" / ES "Reanudar sesión"

### Why
The macOS app is restoring the **Pause / Resume Focus Session** option in the new menu view (Focus-Bear/Mac-App#2148). The redesigned menu dropped it — clicking Stop ended the session with no chance to pause. The Mac fix reads these two keys via `menuLocalized()` from the `menuView` block, so they must exist in the published assets config or the **Config↔Assets sync** check on the Mac PR will fail.

Pairs with the Mac-App PR for #2148.