### PR TITLE
feat(config): dragAwayPostponeVcInfo strings for Mac drag-to-postpone (#2091)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2795,6 +2795,11 @@
         "titleTask": "Título de la tarea:",
         "taskNameString": "Para trabajar en: <URL>"
     },
+    "dragAwayPostponeVcInfo":{
+        "titleText": "Noté que arrastraste la ventana de la rutina matutina a un lado. ¿Quieres posponerla?",
+        "buttonPostponeText": "Posponer",
+        "buttonKeepGoingText": "Continuar"
+    },
     "habitsStateVcInfo":{
         "morningRoutinePostponedText": "Rutina matutina pospuesta. Reanúdala ahora haciendo clic en 'Reanudar hábitos'.",
         "eveningRoutinePostponedText": "Rutina nocturna pospuesta. Reanúdala ahora haciendo clic en 'Reanudar hábitos'.",

--- a/config/config.json
+++ b/config/config.json
@@ -2797,6 +2797,11 @@
         "titleTask": "Task title:",
         "taskNameString": "To work on: <URL>"
     },
+    "dragAwayPostponeVcInfo":{
+        "titleText": "I noticed you dragged the morning routine window away. Do you want to postpone it?",
+        "buttonPostponeText": "Postpone",
+        "buttonKeepGoingText": "Keep going"
+    },
     "habitsStateVcInfo":{
         "morningRoutinePostponedText": "Morning routine postponed. Resume it now by clicking 'Resume Habits'.",
         "eveningRoutinePostponedText": "Evening routine postponed. Resume it now by clicking 'Resume Habits'.",


### PR DESCRIPTION
Companion PR to **Focus-Bear/Mac-App#2156** (issue Focus-Bear/Mac-App#2091).

Adds a new `dragAwayPostponeVcInfo` block to `config/config.json` (English) and `config/config-es.json` (Spanish) for the macOS morning-routine drag-away postpone prompt:

- `titleText` — "I noticed you dragged the morning routine window away. Do you want to postpone it?"
- `buttonPostponeText` — "Postpone"
- `buttonKeepGoingText` — "Keep going"

The Mac-App PR's "Config ↔ Assets Sync" check fails until these keys exist on this repo's `main`, so this needs to merge for that PR to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)