### PR TITLE
feat(config): add menuShortcutHint string (EN + ES) for Mac-App #2003

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2971,6 +2971,7 @@
         "menuPauseMusic": "Pausar música",
         "menuBrainDump": "Volcado de ideas",
         "menuToDoPlayer": "Reproductor de tareas",
+        "menuShortcutHint": "Prueba %1$@ la próxima vez para abrir %2$@",
         "menuTasksForToday": "TAREAS DE HOY",
         "menuDayPlan": "Plan del día",
         "menuViewFullDayPlan": "Ver plan del día completo",

--- a/config/config.json
+++ b/config/config.json
@@ -2973,6 +2973,7 @@
         "menuPauseMusic": "Pause music",
         "menuBrainDump": "Brain Dump",
         "menuToDoPlayer": "To-Do Player",
+        "menuShortcutHint": "Try %1$@ next time to open %2$@",
         "menuTasksForToday": "TASKS FOR TODAY",
         "menuDayPlan": "Day Plan",
         "menuViewFullDayPlan": "View full day plan",


### PR DESCRIPTION
## What

Adds a new `menuView.menuShortcutHint` string to `config/config.json` (English) and `config/config-es.json` (Spanish):

- EN: `Try %1$@ next time to open %2$@`
- ES: `Prueba %1$@ la próxima vez para abrir %2$@`

## Why

Companion to **Mac-App PR #2158** (issue Focus-Bear/Mac-App#2003), which shows a small toast teaching the keyboard shortcut when the user opens Focus Music / Brain Dump / To-Do Player by clicking the menu — e.g. _"Try cmd-alt-m next time to open Focus Music"_. The toast text is config-driven, and Mac-App's `config-assets-sync` CI check requires every local config string to exist in this repo. This unblocks that check.

Positional format args (`%1$@` = spelled-out shortcut, `%2$@` = feature name) so translators can reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)