### PR TITLE
Tab Audit deep-scan strings (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -3107,13 +3107,24 @@
         "buttonExtractURLs": "Extraer URLs de pestañas a CSV",
         "buttonOpenSavedReport": "Abrir informe guardado de auditoría de pestañas",
         "lastReportDateText": "Tu última auditoría se realizó el: <DATE>",
-        "titleTabsCount": "Número de pestañas abiertas:"
+        "titleTabsCount": "Número de pestañas abiertas:",
+        "gettingTabCount": "Obteniendo el número de pestañas…",
+        "noOpenTabs": "No hay pestañas de navegador abiertas.",
+        "totalText": "Total",
+        "statusCollecting": "Recopilando tus pestañas abiertas…",
+        "statusSaved": "Se guardaron <COUNT> pestañas abiertas en el CSV y se abrió. Ya puedes cerrarlas con tranquilidad — tienes una referencia guardada.",
+        "statusCsvLocked": "No se pudo actualizar el CSV: está abierto en otra aplicación. Ciérralo y vuelve a hacer clic en Extraer.",
+        "statusExtractFailed": "No se pudieron extraer las pestañas. Inténtalo de nuevo.",
+        "deepScanTitle": "Recopilando tus pestañas abiertas",
+        "deepScanMessage": "Ten paciencia y no toques el teclado ni el ratón — Focus Bear está recorriendo las pestañas de tu navegador para capturar sus direcciones. Solo tomará un momento.",
+        "deepScanProgress": "Pestaña <DONE> de <TOTAL>"
     },
     "postBrowsersTabAuditVcInfo":{
         "title": "Tus pestañas se han guardado en el archivo CSV. Ahora puedes cerrarlas con tranquilidad, ya que tienes una referencia guardada.",
         "titleSetTabLimit": "Configura un límite de pestañas para no volver a sentirte abrumad@.",
         "titleTabLimitCount": "Límite máximo de pestañas:",
-        "buttonSave": "Guardar"
+        "buttonSave": "Guardar",
+        "buttonCancel": "Cancelar"
     },
     "blockingScheduleEditorVcInfo":{
         "title": "Horario de bloqueo",

--- a/config/config.json
+++ b/config/config.json
@@ -3109,13 +3109,24 @@
         "buttonExtractURLs": "Extract tab URLs to CSV",
         "buttonOpenSavedReport": "Open saved Tab Audit report",
         "lastReportDateText": "Your last audit was done on: <DATE>",
-        "titleTabsCount": "Number of open tabs:"
+        "titleTabsCount": "Number of open tabs:",
+        "gettingTabCount": "Getting tab count…",
+        "noOpenTabs": "No open browser tabs.",
+        "totalText": "Total",
+        "statusCollecting": "Collecting your open tabs…",
+        "statusSaved": "Saved <COUNT> open tabs to the CSV and opened it. You can safely close them now — you have a reference stored.",
+        "statusCsvLocked": "Couldn't update the CSV — it's open in another app. Close it, then click Extract again.",
+        "statusExtractFailed": "Couldn't extract tabs. Please try again.",
+        "deepScanTitle": "Collecting your open tabs",
+        "deepScanMessage": "Please be patient and don't touch your keyboard or mouse — Focus Bear is stepping through your browser tabs to capture their addresses. This only takes a moment.",
+        "deepScanProgress": "Tab <DONE> of <TOTAL>"
     },
     "postBrowsersTabAuditVcInfo":{
         "title": "Your tabs have been saved to the CSV file. You can safely close them now, since you have a reference stored.",
         "titleSetTabLimit": "Set a tab limit so you don't get overwhelmed with tabs again",
         "titleTabLimitCount": "Max tab limit:",
-        "buttonSave": "Save"
+        "buttonSave": "Save",
+        "buttonCancel": "Cancel"
     },
     "blockingScheduleEditorVcInfo":{
         "title": "Blocking Schedule",


### PR DESCRIPTION
Adds config strings for the Windows **Tab Audit deep scan** feature (capturing every open tab's URL across Firefox + Chromium browsers).

### New keys
**`browsersTabAuditVcInfo`**
- `gettingTabCount` — loading label shown while the tab count is being read
- `noOpenTabs`
- `totalText` — "Total" line in the per-browser count
- `statusCollecting`, `statusSaved` (uses `<COUNT>`), `statusCsvLocked`, `statusExtractFailed` — extract status messages
- `deepScanTitle`, `deepScanMessage` — full-screen scan overlay text
- `deepScanProgress` — progress line (uses `<DONE>` / `<TOTAL>`)

**`postBrowsersTabAuditVcInfo`**
- `buttonCancel`

English and Spanish provided. Windows app PR: Focus-Bear/windows-app-v2 (feat/tab-audit-firefox-deep-scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)