### PR TITLE
Make dragAwayPostpone title generic (routine, not "morning") — Mac #2091

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2796,7 +2796,7 @@
         "taskNameString": "Para trabajar en: <URL>"
     },
     "dragAwayPostponeVcInfo":{
-        "titleText": "Noté que arrastraste la ventana de la rutina matutina a un lado. ¿Quieres posponerla?",
+        "titleText": "Noté que moviste la ventana de la rutina a un lado. ¿Quieres posponerla?",
         "buttonPostponeText": "Posponer",
         "buttonKeepGoingText": "Continuar"
     },

--- a/config/config.json
+++ b/config/config.json
@@ -2798,7 +2798,7 @@
         "taskNameString": "To work on: <URL>"
     },
     "dragAwayPostponeVcInfo":{
-        "titleText": "I noticed you dragged the morning routine window away. Do you want to postpone it?",
+        "titleText": "I noticed you moved the routine window away. Do you want to postpone it?",
         "buttonPostponeText": "Postpone",
         "buttonKeepGoingText": "Keep going"
     },


### PR DESCRIPTION
The macOS drag-away postpone prompt (Focus-Bear/Mac-App#2091, PR #2156) now covers **morning and evening** routines, and its trigger moved to the small draggable routine window. So the copy should not say "morning".

Generalises `dragAwayPostponeVcInfo.titleText` in EN + ES:
- EN: "I noticed you moved the routine window away. Do you want to postpone it?"
- ES: "Noté que moviste la ventana de la rutina a un lado. ¿Quieres posponerla?"

`buttonPostponeText` / `buttonKeepGoingText` unchanged. Pairs with the Mac-App PR.