### PR TITLE
Add Focus Button connection/firmware strings + tab-limit saved state (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2123,7 +2123,20 @@
         "alwaysAllowedAppsTitle": "Aplicaciones siempre permitidas",
         "titleFocusButton": "Botón de enfoque",
         "descriptionFocusButton": "El dispositivo FocusButton se conecta a tu computadora mediante un cable USB y funciona junto con la app para ayudarte a gestionar sesiones de enfoque y acciones. Una vez conectado, la app detecta automáticamente el dispositivo y establece comunicación con él.",
-        "buttonConnectFocusButton": "Conectar"
+        "buttonConnectFocusButton": "Conectar",
+        "focusButtonStateConnectedText": "CONECTADO",
+        "focusButtonStateConnectingText": "CONECTANDO…",
+        "focusButtonStateDisconnectedText": "DESCONECTADO",
+        "focusButtonNoDeviceTitle": "¿No tienes un dispositivo Focus Button?",
+        "buttonGetFocusButtonDeviceText": "Consigue un dispositivo Focus Button",
+        "focusButtonInstalledFirmwareTitle": "FIRMWARE INSTALADO",
+        "focusButtonVersionLabel": "Versión: ",
+        "buttonCheckForFirmwareUpdatesText": "Buscar actualizaciones",
+        "focusButtonUpdateAvailableText": "Hay una nueva versión disponible. Haz clic en Actualizar Firmware para descargar e instalar la última versión del firmware en el dispositivo",
+        "buttonFlashFirmwareText": "Actualizar Firmware",
+        "focusButtonFirmwareDownloadedText": "Se descargaron nuevas actualizaciones de firmware. Haz clic en el botón \"Actualizar Firmware\" para instalar la última versión en el dispositivo. Este proceso reinicia el dispositivo en modo bootloader, verifica que la imagen coincida con el chip y lo reinicia — la configuración y los hábitos guardados en NVS se mantienen. La conexión serial se libera durante la actualización y se restablece al finalizar.",
+        "focusButtonFlashCompleteText": "Actualización completa — el dispositivo se está reiniciando.",
+        "focusButtonNotDetectedText": "No detectado — haz clic en \"Buscar actualizaciones\" para instalar el firmware"
     },
     "impactMeasurementVcInfo": {
         "title": "Analiza tu sueño y estado de ánimo",
@@ -3124,6 +3137,7 @@
         "titleSetTabLimit": "Configura un límite de pestañas para no volver a sentirte abrumad@.",
         "titleTabLimitCount": "Límite máximo de pestañas:",
         "buttonSave": "Guardar",
+        "buttonSaved": "¡Guardado!",
         "buttonCancel": "Cancelar"
     },
     "blockingScheduleEditorVcInfo":{

--- a/config/config.json
+++ b/config/config.json
@@ -2125,7 +2125,20 @@
         "alwaysAllowedAppsTitle": "Always Allowed Apps",
         "titleFocusButton": "Focus Button",
         "descriptionFocusButton": "The FocusButton device connects to your computer using a USB cable and works together with the app to help manage focus sessions and actions. Once connected, the app automatically detects the device and establishes communication with it.",
-        "buttonConnectFocusButton": "Connect"
+        "buttonConnectFocusButton": "Connect",
+        "focusButtonStateConnectedText": "CONNECTED",
+        "focusButtonStateConnectingText": "CONNECTING…",
+        "focusButtonStateDisconnectedText": "DISCONNECTED",
+        "focusButtonNoDeviceTitle": "Do not have a Focus Button Device?",
+        "buttonGetFocusButtonDeviceText": "Get a Focus Button Device",
+        "focusButtonInstalledFirmwareTitle": "INSTALLED FIRMWARE",
+        "focusButtonVersionLabel": "Version: ",
+        "buttonCheckForFirmwareUpdatesText": "Check for Updates",
+        "focusButtonUpdateAvailableText": "A new version is available. Click Flash Firmware to download and install the latest Firmware on the device",
+        "buttonFlashFirmwareText": "Flash Firmware",
+        "focusButtonFirmwareDownloadedText": "New Firmware updates downloaded. Click on \"Flash Firmware\" button to install the latest firmware on the device. Flashing reboots the device into its bootloader, verifies the image matches the chip, and restarts — settings and habits in NVS are kept. The serial connection is released during flashing and restored afterwards.",
+        "focusButtonFlashCompleteText": "Flash complete — device is rebooting.",
+        "focusButtonNotDetectedText": "Not detected — click \"Check for Updates\" to install firmware"
     },
     "impactMeasurementVcInfo": {
         "title": "Analyse Your Sleep and Mood",
@@ -3126,6 +3139,7 @@
         "titleSetTabLimit": "Set a tab limit so you don't get overwhelmed with tabs again",
         "titleTabLimitCount": "Max tab limit:",
         "buttonSave": "Save",
+        "buttonSaved": "Saved!",
         "buttonCancel": "Cancel"
     },
     "blockingScheduleEditorVcInfo":{


### PR DESCRIPTION
Add new config keys for Focus Button device management and tab-limit UI:

**settingsNew section (13 keys):**
- focusButtonStateConnectedText, focusButtonStateConnectingText, focusButtonStateDisconnectedText
- focusButtonNoDeviceTitle, buttonGetFocusButtonDeviceText
- focusButtonInstalledFirmwareTitle, focusButtonVersionLabel
- buttonCheckForFirmwareUpdatesText, focusButtonUpdateAvailableText, buttonFlashFirmwareText
- focusButtonFirmwareDownloadedText, focusButtonFlashCompleteText
- focusButtonNotDetectedText

**postBrowsersTabAuditVcInfo section (1 key):**
- buttonSaved

These strings enable the windows-app-v2 FocusButton preferences tab and AdvancedTab to read UI text from config instead of hardcoded literals (windows-app-v2 PR: https://github.com/Focus-Bear/windows-app-v2/pull/1068).

EN + ES translations provided.