### PR TITLE
config: menuHabitsPostponedUntil string (EN + ES) for Mac menu

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -3030,6 +3030,7 @@
         "menuFocusGoalPlaceholder": "Escribe aquí tu objetivo de enfoque",
         "menuNextEventLabel": "PRÓXIMO EVENTO",
         "menuNextHabitLabel": "PRÓXIMO HÁBITO",
+        "menuHabitsPostponedUntil": "Hábitos pospuestos hasta %@",
         "menuNothingScheduled": "Nada programado en este momento",
         "menuBlockingScheduleActive": "Horario de bloqueo activo",
         "menuBlockingSchedulePaused": "Horario de bloqueo en pausa",

--- a/config/config.json
+++ b/config/config.json
@@ -3032,6 +3032,7 @@
         "menuFocusGoalPlaceholder": "Enter Focus Goal here",
         "menuNextEventLabel": "NEXT EVENT",
         "menuNextHabitLabel": "NEXT HABIT",
+        "menuHabitsPostponedUntil": "Habits postponed until %@",
         "menuNothingScheduled": "Nothing scheduled right now",
         "menuBlockingScheduleActive": "Blocking schedule active",
         "menuBlockingSchedulePaused": "Blocking schedule paused",


### PR DESCRIPTION
Companion to Focus-Bear/Mac-App#2175. Adds `menuHabitsPostponedUntil` ("Habits postponed until %@" / "Hábitos pospuestos hasta %@") under the `menuView` block in both config.json and config-es.json, so the Mac menu's 'Habits postponed until <time>' line resolves from assets and the Mac PR's config-strings CI check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)