### PR TITLE
config: evening postpone hold-to-set strings (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -1204,7 +1204,10 @@
         "buttonSkipCompletelyText": "Saltar completamente",
         "titleAskOfficeMode": "¿No tienes tiempo para un descanso en este momento o estas en la oficina y no es apropiado hacer <ACTIVITY>?",
         "buttonDontHaveTimeText": "No tengo tiempo",
-        "buttonInTheOffIceText": "Estoy en la oficina"
+        "buttonInTheOffIceText": "Estoy en la oficina",
+        "eveningHoldInstruction": "Mantén pulsado para elegir cuánto tiempo posponer: cuanto más tiempo mantengas, más largo será el aplazamiento. Suelta para confirmar.",
+        "eveningHoldLiveText": "Posponer <MIN> min…",
+        "eveningHoldIdleText": "Mantén pulsado para posponer"
     },
     "breakFrequencyVcInfo": {
         "title": "¿Quieres que los descansos sean menos frecuentes?",

--- a/config/config.json
+++ b/config/config.json
@@ -1204,7 +1204,10 @@
         "buttonSkipCompletelyText": "Skip Completely",
         "titleAskOfficeMode": "Do you not have time for a break right now or are you in the office and it's not appropriate to do <ACTIVITY>?",
         "buttonDontHaveTimeText": "I don't have time",
-        "buttonInTheOffIceText": "I'm in the offIce"
+        "buttonInTheOffIceText": "I'm in the offIce",
+        "eveningHoldInstruction": "Press and hold to choose how long to postpone — the longer you hold, the longer the postpone. Release to confirm.",
+        "eveningHoldLiveText": "Postpone for <MIN> min…",
+        "eveningHoldIdleText": "Hold to postpone"
     },
     "breakFrequencyVcInfo": {
         "title": "Want to make breaks less frequent?",


### PR DESCRIPTION
## What
Adds config strings for the Mac app's new **evening-routine "hold-to-set" postpone** control (press-and-hold to accumulate the postpone duration, instead of picking from a dropdown).

New keys under `activityPostponeInfo` in both `config/config.json` (EN) and `config/config-es.json` (ES):

- `eveningHoldInstruction` — the press-and-hold instruction line
- `eveningHoldLiveText` — live label while holding, contains a `<MIN>` placeholder replaced with the accumulating minute count
- `eveningHoldIdleText` — button label before the user starts holding

## Why
Companion to **Focus-Bear/Mac-App** `feat/evening-postpone-hold-to-set`. The Mac PR's "Local config strings exist in assets repo" CI check depends on these keys existing here, so this needs to merge first / alongside.

## Verification
Both JSON files validated with `json.load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)