### PR TITLE
config(menuView): add Windows tray menu strings (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -3068,7 +3068,18 @@
         "menuLastBreak": "Último descanso",
         "menuAgo": "atrás",
         "dayPlanStartsAt": "empieza a las",
-        "dayPlanIn": "en"
+        "dayPlanIn": "en",
+        "menuDayPlanSubtitle": "Consulta tu día",
+        "menuLastHabit": "Este es el último hábito",
+        "menuBreaksOff": "Los descansos están desactivados",
+        "menuBreaksOffBody": "Activa los descansos en los ajustes para descansar con regularidad.",
+        "menuNextBreakIn": "Próximo descanso en %d min",
+        "menuNextBreakAt": "Tu próximo descanso es a las %@.",
+        "menuBreakDueNow": "Descanso pendiente ahora",
+        "menuBreakDueNowBody": "Es hora de un descanso.",
+        "menuTakeBreakSubtitle": "Tómate un descanso",
+        "menuTakeBreakBody": "Tómate un descanso cuando lo necesites.",
+        "menuOpenFocusScreen": "Abre la pantalla de enfoque completa"
     },
     "leftMenuVcInfo":{
         "menuStats": "Estadísticas",

--- a/config/config.json
+++ b/config/config.json
@@ -3070,7 +3070,18 @@
         "menuLastBreak": "Last break",
         "menuAgo": "ago",
         "dayPlanStartsAt": "starts at",
-        "dayPlanIn": "in"
+        "dayPlanIn": "in",
+        "menuDayPlanSubtitle": "View your day",
+        "menuLastHabit": "This is the last habit",
+        "menuBreaksOff": "Breaks are turned off",
+        "menuBreaksOffBody": "Turn on breaks in settings to take regular breaks.",
+        "menuNextBreakIn": "Next break in %d min",
+        "menuNextBreakAt": "Your next break is at %@.",
+        "menuBreakDueNow": "Break due now",
+        "menuBreakDueNowBody": "It's time for a break.",
+        "menuTakeBreakSubtitle": "Take a break",
+        "menuTakeBreakBody": "Take a break whenever you need one.",
+        "menuOpenFocusScreen": "Open the full focus screen"
     },
     "leftMenuVcInfo":{
         "menuStats": "Stats",


### PR DESCRIPTION
## What
Adds the tray-menu strings the Windows app's redesigned menu needs, under `menuView`, so they're config-driven/localizable like the rest of the menu.

macOS already added `menuHabitsPostponedUntil`; these are the remaining Windows-only strings:

| Key | EN | ES |
|-----|----|----|
| menuDayPlanSubtitle | View your day | Consulta tu día |
| menuLastHabit | This is the last habit | Este es el último hábito |
| menuBreaksOff | Breaks are turned off | Los descansos están desactivados |
| menuBreaksOffBody | Turn on breaks in settings to take regular breaks. | Activa los descansos en los ajustes para descansar con regularidad. |
| menuNextBreakIn | Next break in %d min | Próximo descanso en %d min |
| menuNextBreakAt | Your next break is at %@. | Tu próximo descanso es a las %@. |
| menuBreakDueNow | Break due now | Descanso pendiente ahora |
| menuBreakDueNowBody | It's time for a break. | Es hora de un descanso. |
| menuTakeBreakSubtitle | Take a break | Tómate un descanso |
| menuTakeBreakBody | Take a break whenever you need one. | Tómate un descanso cuando lo necesites. |
| menuOpenFocusScreen | Open the full focus screen | Abre la pantalla de enfoque completa |

## Why
The Windows tray redesign (Day Plan card, inline focus picker, Breaks card) currently hardcodes these strings. Wiring them to `menuView` makes them translatable; the Windows app reads them with English fallbacks so it degrades gracefully before the config downloads.

## Notes
- `%d` / `%@` are the count / time placeholders the Windows app substitutes.
- ES translations are a first pass — happy to adjust to the team's preferred wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)