### PR TITLE
config(habitsStateVcInfo): add cancelled-routine messages (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2837,6 +2837,8 @@
         "nextRoutineTimeCancelledMorninigRoutine": "Has cancelado tu rutina de la mañana de hoy.\nTu próxima rutina programada (<ROUTINE>) comenzará a las <TIME>. Prepárate para retomarla y seguir fortaleciendo esos hábitos saludables. ¡Tú puedes!",
         "buttonUncancelEveningRoutine": "Restaurar mi rutina de la tarde",
         "buttonUncancelMorningRoutine": "Restaurar mi rutina de la mañana",
+        "cancelledMorningRoutineMessage": "Cancelaste tu rutina de la mañana. Si cambiaste de opinión, haz clic en \"Restaurar mi rutina de la mañana\" para continuar con tus hábitos matutinos.",
+        "cancelledEveningRoutineMessage": "Cancelaste tu rutina de la tarde. Si cambiaste de opinión, haz clic en \"Restaurar mi rutina de la tarde\" para continuar con tus hábitos de la tarde.",
         "restoreRoutineFailedText": "No pudimos restaurar tu rutina en este momento. Inténtalo de nuevo.",
         "setSleepTimeCancelledEveningRoutineWithUndo": "No tienes configurada una hora de sueño.\n\n(Por cierto, cancelaste tu rutina de la tarde. Si cambiaste de opinión y quieres realizar tus hábitos de la tarde, haz clic en Restaurar mi rutina de la tarde).",
         "sleepTimeCancelledEveningRoutineWithUndo": "Tu hora de dormir es a las <CUTOFFTIME>.\n\n(Por cierto, cancelaste tu rutina de la tarde. Si cambiaste de opinión y quieres realizar tus hábitos de la tarde, haz clic en Restaurar mi rutina de la tarde).",

--- a/config/config.json
+++ b/config/config.json
@@ -2839,6 +2839,8 @@
         "nextRoutineTimeCancelledMorninigRoutine": "You cancelled your morning routine for today.\nYour next scheduled routine (<ROUTINE>) is set for <TIME>. Be ready to jump back in and continue building those healthy habits. You've got this!",
         "buttonUncancelEveningRoutine": "Uncancel my evening routine",
         "buttonUncancelMorningRoutine": "Uncancel my morning routine",
+        "cancelledMorningRoutineMessage": "You cancelled your morning routine. If you changed your mind, click \"Uncancel My Morning Routine\" to continue your morning habits.",
+        "cancelledEveningRoutineMessage": "You cancelled your evening routine. If you changed your mind, click \"Uncancel My Evening Routine\" to continue your evening habits.",
         "restoreRoutineFailedText": "We couldn't restore your routine right now. Please try again.",
         "setSleepTimeCancelledEveningRoutineWithUndo": "You do not have sleep time set.\n\n(By the way, you cancelled your evening routine. if you changed your mind and want to do your evening habits click Uncancel my evening routine)",
         "sleepTimeCancelledEveningRoutineWithUndo": "Your sleep time is <CUTOFFTIME>.\n\n(By the way, you cancelled your evening routine. if you changed your mind and want to do your evening habits click Uncancel my evening routine)",


### PR DESCRIPTION
## What
Adds the two cancelled-routine message strings the Windows Day Plan's **Uncancel Routine** feature shows on a force-cancelled routine's card, under `habitsStateVcInfo`:

| Key | EN | ES |
|-----|----|----|
| cancelledMorningRoutineMessage | You cancelled your morning routine. If you changed your mind, click "Uncancel My Morning Routine" to continue your morning habits. | Cancelaste tu rutina de la mañana. Si cambiaste de opinión, haz clic en "Restaurar mi rutina de la mañana" para continuar con tus hábitos matutinos. |
| cancelledEveningRoutineMessage | You cancelled your evening routine. If you changed your mind, click "Uncancel My Evening Routine" to continue your evening habits. | Cancelaste tu rutina de la tarde. Si cambiaste de opinión, haz clic en "Restaurar mi rutina de la tarde" para continuar con tus hábitos de la tarde. |

## Why
The `buttonUncancel*` and `restoreRoutineFailedText` keys already exist in `habitsStateVcInfo`; only these two message strings were missing. The Windows app reads them with English fallbacks, so ES users need them here to get the translation.

ES translations are a first pass — happy to adjust to the team's preferred wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)