### PR TITLE
config: add aiNotApplicableText (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2762,6 +2762,7 @@
         "toolTipShowToDoPlayer": "Mostrar reproductor de tareas",
         "currentTaskText": "La tarea actual es \"<TASK>\"",
         "aiIsDisabledText": "La IA no está activada.",
+        "aiNotApplicableText": "La IA no es aplicable.",
         "noCurrentTaskText": "Sin tarea actual",
         "toolTipAlignmentScore": "Esto muestra el % del tiempo que has estado en sitios web/apps relevantes para tu objetivo de enfoque. Usamos IA para comprobar la relevancia.",
         "aiScoreNotCalculatedText": "Puntaje de IA no calculado."

--- a/config/config.json
+++ b/config/config.json
@@ -2764,6 +2764,7 @@
         "toolTipShowToDoPlayer": "Show To Do Player",
         "currentTaskText": "Current task is \"<TASK>\"",
         "aiIsDisabledText": "AI is not enabled.",
+        "aiNotApplicableText": "AI not applicable.",
         "noCurrentTaskText": "No Current Task",
         "toolTipAlignmentScore": "This shows what % of the time you've been on websites/apps that are relevant to your focus goal. We use AI to check the relevance.",
         "aiScoreNotCalculatedText": "AI score not calculated."


### PR DESCRIPTION
Adds a new string `aiNotApplicableText` to the `nudgeFocusAlignmentScoreDippingVcInfo` block, in both `config/config.json` (EN) and `config/config-es.json` (ES).

- EN: `AI not applicable.`
- ES: `La IA no es aplicable.`

## Why
The Mac app now shows **"AI not applicable."** (instead of "AI is not enabled.") on the focus-alignment nudge during a **super-distracting focus session**. This mirror keeps the assets repo in sync so the Mac-App CI check *"Local config strings exist in assets repo"* passes for the paired Mac-App change.

Pairs with the Mac-App PR for the super-distracting AI message/score behavior.