### PR TITLE
Rename "Start focus session" shortcut label to "Open Focus Session" (Mac #2166)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -3392,7 +3392,7 @@
         "brainDumpTitle": "Abrir Brain Dump:",
         "focusMusicTitle": "Abrir Focus Music:",
         "taskListTitle": "Abrir lista de tareas:",
-        "focusSessionTitle": "Iniciar sesión de enfoque:"
+        "focusSessionTitle": "Abrir sesión de enfoque:"
     },
     "discordUrl": "https://discord.gg/VZdv3ZjhSq",
     "whatsAppUrl": "https://chat.whatsapp.com/FV0oTbCUWpILBYif7CP6UD",

--- a/config/config.json
+++ b/config/config.json
@@ -3394,7 +3394,7 @@
         "brainDumpTitle": "Open Brain Dump:",
         "focusMusicTitle": "Open Focus Music:",
         "taskListTitle": "Open Task List:",
-        "focusSessionTitle": "Start focus session:"
+        "focusSessionTitle": "Open Focus Session:"
     },
     "discordUrl": "https://discord.gg/VZdv3ZjhSq",
     "whatsAppUrl": "https://chat.whatsapp.com/FV0oTbCUWpILBYif7CP6UD",


### PR DESCRIPTION
Mirrors the Mac-App config change for [Mac-App#2166](https://github.com/Focus-Bear/Mac-App/issues/2166).

## Why

The keyboard-shortcut label **"Start focus session"** implied that pressing it immediately begins a focus session. It actually only opens the Start Focus Session screen, where the user still has to start the session manually. Renaming to **"Open Focus Session"** sets the correct expectation and matches the sibling shortcut labels ("Open Brain Dump", "Open Focus Music", "Open Task List").

## Changes

Under `keyboardShortcutsSettingsVcInfo`:

- `config/config.json`: `focusSessionTitle` → `"Open Focus Session:"`
- `config/config-es.json`: `focusSessionTitle` → `"Abrir sesión de enfoque:"`

Paired with the Mac-App PR (same rename in local `config.json` / `config-es.json` + Swift fallback). Required so the Mac-App CI check "Local config strings exist in assets repo" passes.