### PR TITLE
config(breakStateVcInfo): add buttonAddBreakActivity (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2852,6 +2852,7 @@
         "shutoffTimeText": "La app está en estado de apagado",
         "noBreakScheduledText": "Aún no se ha programado ningún descanso próximo.",
         "noBreakAddedText": "Aún no se han agregado actividades de descanso.",
+        "buttonAddBreakActivity": "Agregar actividad de descanso",
         "buttonChangeTiming": "Cambiar horario"
     },
     "scheduleViewInfo":{

--- a/config/config.json
+++ b/config/config.json
@@ -2854,6 +2854,7 @@
         "shutoffTimeText": "App is in shutoff state",
         "noBreakScheduledText": "No upcoming break has been scheduled yet.",
         "noBreakAddedText": "No break activities added yet.",
+        "buttonAddBreakActivity": "Add break activity",
         "buttonChangeTiming": "Change Timing"
     },
     "scheduleViewInfo":{


### PR DESCRIPTION
Adds `buttonAddBreakActivity` to `breakStateVcInfo` (EN + ES). The Windows tray Breaks card shows this "Add break activity" link when no break activities are configured (it opens Edit Habits). `noBreakAddedText` already existed; only the button string was missing.

| Key | EN | ES |
|-----|----|----|
| buttonAddBreakActivity | Add break activity | Agregar actividad de descanso |

🤖 Generated with [Claude Code](https://claude.com/claude-code)