### PR TITLE
i18n: add Day Plan 'Hide habits' setting string (EN/ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2914,6 +2914,7 @@
         "showEventAgain": "Volver a mostrar este evento",
         "hideEvent": "Ocultar este evento",
         "showEarlierEvents": "Mostrar eventos anteriores de hoy",
+        "hideHabitBlocks": "Ocultar hábitos",
         "hideEarlierEvents": "Ocultar eventos anteriores de hoy",
         "viewTomorrow": "Ver el horario de mañana",
         "editEventTitle": "Editar evento",

--- a/config/config.json
+++ b/config/config.json
@@ -2916,6 +2916,7 @@
         "showEventAgain": "Show this event again",
         "hideEvent": "Hide this event",
         "showEarlierEvents": "Show events from earlier today",
+        "hideHabitBlocks": "Hide habits",
         "hideEarlierEvents": "Hide events from earlier today",
         "viewTomorrow": "View tomorrow's schedule",
         "editEventTitle": "Edit event",


### PR DESCRIPTION
Adds `scheduleViewInfo.hideHabitBlocks` (EN: "Hide habits", ES: "Ocultar hábitos") used by the Mac app's new **Schedule settings → "Hide habits"** toggle.

Pairs with Mac-App PR https://github.com/Focus-Bear/Mac-App/pull/2235 — that PR's "Local config strings exist in assets repo" CI check is red until this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)