### PR TITLE
config: add teacherSessionInfo.appBlockedRequestUnlockText (EN/ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -3230,6 +3230,7 @@
         "lockedAlertTitle": "Esta sesión está controlada por tu profesor(a)",
         "lockedAlertBody": "No puedes detener ni pausar esta sesión de enfoque antes de tiempo. Termina cuando tu profesor(a) la finalice o se alcance la hora de finalización programada. ¿Necesitas desbloquear una aplicación o un sitio web? Envía una solicitud de desbloqueo a tu profesor(a).",
         "buttonRequestUnlock": "Solicitar desbloqueo",
+        "appBlockedRequestUnlockText": "<APP_NAME> está bloqueada durante tu sesión de clase. Pídele a tu profesor(a) que la desbloquee.",
         "unlockDeclinedTitle": "Solicitud de desbloqueo rechazada",
         "unlockDeclinedBody": "Tu profesor(a) ha rechazado tu solicitud de desbloqueo.",
         "titleCreateUnlockRequest": "Pide a tu profesor(a) que desbloquee una aplicación o un sitio web",

--- a/config/config.json
+++ b/config/config.json
@@ -3232,6 +3232,7 @@
         "lockedAlertTitle": "This session is controlled by your teacher",
         "lockedAlertBody": "You can't stop or pause this focus session early. It ends when your teacher ends it or the scheduled finish time is reached. Need an app or website unlocked? Send your teacher an unlock request.",
         "buttonRequestUnlock": "Request unlock",
+        "appBlockedRequestUnlockText": "<APP_NAME> is blocked during your class session. Ask your teacher to unlock it.",
         "unlockDeclinedTitle": "Unlock request declined",
         "unlockDeclinedBody": "Your teacher declined your unlock request.",
         "titleCreateUnlockRequest": "Ask your teacher to unlock an app or website",


### PR DESCRIPTION
Adds a new config string used by the Windows app's Teacher Mode "Request unlock on blocked-app notification" feature (Focus-Bear/windows-app-v2#1411).

## Key
`teacherSessionInfo.appBlockedRequestUnlockText` — shown in the top-right notification when a student opens a blocked app during a class session; `<APP_NAME>` is substituted with the app name.

- **EN** (`config/config.json`): `"<APP_NAME> is blocked during your class session. Ask your teacher to unlock it."`
- **ES** (`config/config-es.json`): `"<APP_NAME> está bloqueada durante tu sesión de clase. Pídele a tu profesor(a) que la desbloquee."`

## Why
The Windows app downloads and **replaces** its bundled config with this repo's at runtime, so the key must live here for the string (especially the Spanish translation) to appear. The app has a hardcoded English fallback, so without this PR EN still works but ES would show English.

Reused the existing `buttonRequestUnlock` label for the button, so no new button string was needed.