### PR TITLE
Add Day Plan "not enough time" strings (EN + ES) — Windows #1371

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2892,6 +2892,8 @@
         "eveningRoutine": "Rutina nocturna",
         "morningRoutine": "Rutina matutina",
         "noHabitsLeft": "No quedan hábitos por ahora: ¡disfruta tu tiempo libre! 🎉",
+        "dayPlanNotEnoughTimeHeading": "⏰ No hay tiempo libre suficiente hoy",
+        "dayPlanNotEnoughTime": "Tus reuniones ocupan el resto del día, así que no hay tiempo libre suficiente para toda tu rutina. Aun así puedes empezarla abajo o posponerla.",
         "nothingScheduled": "Nada programado para este día.",
         "calendarBanner": "Conecta tu calendario para ver reuniones y tiempo libre para trabajo profundo.",
         "grantAccess": "Conceder acceso",

--- a/config/config.json
+++ b/config/config.json
@@ -2894,6 +2894,8 @@
         "eveningRoutine": "Evening routine",
         "morningRoutine": "Morning routine",
         "noHabitsLeft": "No habits left for now — enjoy your free time! 🎉",
+        "dayPlanNotEnoughTimeHeading": "⏰ Not enough free time today",
+        "dayPlanNotEnoughTime": "Your meetings fill the rest of today, so there isn't enough free time for your whole routine. You can still start it below, or postpone it.",
         "nothingScheduled": "Nothing scheduled for this day.",
         "calendarBanner": "Connect your calendar to see meetings and free time for deep work.",
         "grantAccess": "Grant access",


### PR DESCRIPTION
Adds two `scheduleViewInfo` strings used by the Windows Day Plan fix for [windows-app-v2#1371](https://github.com/Focus-Bear/windows-app-v2/issues/1371) (morning routine can't start when the calendar is fully booked).

When the active routine's habits don't fit around the day's meetings, the routine card now shows a short heading in place of the time range, with the full explanation on expand:

| key | EN | ES |
|---|---|---|
| `dayPlanNotEnoughTimeHeading` | ⏰ Not enough free time today | ⏰ No hay tiempo libre suficiente hoy |
| `dayPlanNotEnoughTime` | Your meetings fill the rest of today, so there isn't enough free time for your whole routine. You can still start it below, or postpone it. | Tus reuniones ocupan el resto del día, así que no hay tiempo libre suficiente para toda tu rutina. Aun así puedes empezarla abajo o posponerla. |

The Windows app already ships English fallbacks in code, so EN users are covered even without this; this PR adds the keys to the shared remote config so **Spanish** users get the translated text (the downloaded config replaces the bundled one at runtime).

Added to `config/config.json` and `config/config-es.json`, right after `noHabitsLeft` in the `scheduleViewInfo` block. No other lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)