### PR TITLE
Add 'micro-breaks off during focus' strings (EN + ES) — windows #1215

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -2850,6 +2850,8 @@
         "buttonEnableBreaks": "Activar descansos",
         "buttonStartBreak": "Iniciar descanso",
         "titleEnableBreaks": "Los descansos están desactivados. Activa los descansos a intervalos regulares para aumentar tu productividad, energía y enfoque.",
+        "titleSkipMicroBreaksOn": "Hay una sesión de enfoque en curso con los microdescansos desactivados.",
+        "txtEnableMicroBreaksForFocusSession": "Reanudar los descansos automáticos de esta sesión",
         "pausedBreaksText": "Has pausado los descansos por hoy. Mañana volverán para ayudarte a recargar energías y mantener el enfoque.",
         "shutoffTimeText": "La app está en estado de apagado",
         "noBreakScheduledText": "Aún no se ha programado ningún descanso próximo.",

--- a/config/config.json
+++ b/config/config.json
@@ -2852,6 +2852,8 @@
         "buttonEnableBreaks": "Enable Breaks",
         "buttonStartBreak": "Start Break",
         "titleEnableBreaks": "Breaks are currently disabled. Enable taking breaks at regular intervals to boost your productivity, energy levels, and focus.",
+        "titleSkipMicroBreaksOn": "A focus session is running with micro-breaks turned off.",
+        "txtEnableMicroBreaksForFocusSession": "Resume automatic breaks for this session",
         "pausedBreaksText": "You’ve paused breaks for today. They’ll be back tomorrow to help you recharge and focus.",
         "shutoffTimeText": "App is in shutoff state",
         "noBreakScheduledText": "No upcoming break has been scheduled yet.",


### PR DESCRIPTION
Adds two `breakStateVcInfo` strings used by the Windows fix for [windows-app-v2#1215](https://github.com/Focus-Bear/windows-app-v2/issues/1215) (app PR windows-app-v2#1442) — the "micro-breaks are off during this focus session" state on the Micro Breaks page and the tray Breaks card.

| key | EN | ES |
|---|---|---|
| `titleSkipMicroBreaksOn` | A focus session is running with micro-breaks turned off. | Hay una sesión de enfoque en curso con los microdescansos desactivados. |
| `txtEnableMicroBreaksForFocusSession` | Resume automatic breaks for this session | Reanudar los descansos automáticos de esta sesión |

The Windows app ships English fallbacks in code, so EN is covered even without this; this adds the keys to the shared remote config so **Spanish** users get the translated text (the downloaded config replaces the bundled one at runtime). Added to `config/config.json` and `config/config-es.json` right after `titleEnableBreaks` in the `breakStateVcInfo` block; no other lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)