### PR TITLE
Add cutOffTimePassedSubText string (auto-start high-priority habits)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -229,6 +229,7 @@
         "otherReasonText": "Otro",
         "loadingText": "Cargando",
         "cutOffTimePassedText": "Se está acabando el tiempo - concentrémonos en los hábitos de alta prioridad para el resto de la noche.",
+        "cutOffTimePassedSubText": "Tus hábitos de alta prioridad comenzarán en 5 segundos.",
         "noHighPriorityActivityText": "No se encontraron actividades con alta prioridad.",
         "focusEndsText": "El modo de enfoque termina en",
         "postponeEndsText": "El hábito se reanuda en",

--- a/config/config.json
+++ b/config/config.json
@@ -229,6 +229,7 @@
         "otherReasonText": "Other",
         "loadingText": "Loading...",
         "cutOffTimePassedText": "Running low on time - let's just focus on the high priority habits for the rest of the evening.",
+        "cutOffTimePassedSubText": "Your high priority habits will start in 5 seconds.",
         "noHighPriorityActivityText": "No activities with high Priority found.",
         "focusEndsText": "Focus mode ends in",
         "postponeEndsText": "Habit resumes in",


### PR DESCRIPTION
Adds a new `common.cutOffTimePassedSubText` string used by the Windows app's evening-habits cutoff flow.

At the cutoff time the Windows app now shows an **auto-closing** message and starts the high-priority habits automatically instead of waiting for the user to click OK (windows-app-v2 #866). This string is the subheading shown under the existing `cutOffTimePassedText` heading, telling the user the habits will start shortly.

- `config/config.json` (EN): `"Your high priority habits will start in 5 seconds."`
- `config/config-es.json` (ES): `"Tus hábitos de alta prioridad comenzarán en 5 segundos."`

Additive only — one line per file, placed right after `cutOffTimePassedText`. The Windows app has an English code fallback, so EN works before this merges; this PR delivers the config-sourced string and the Spanish translation to online users.
