### PR TITLE
Add Accountability Buddy refresh unlock strings (EN + ES)

### DIFF
--- a/config/config-es.json
+++ b/config/config-es.json
@@ -3219,6 +3219,8 @@
         "pleaseWaitText": "Por favor espera a que tu compañer@ acepte la invitación antes de crear una solicitud de desbloqueo.",
         "callBuddyText": "Te sugerimos que llames a tu compañer@ {0} y les pidas que te desbloqueen. Recibirán un correo con las instrucciones.",
         "requestFailedText": "Error al crear la solicitud. Por favor, inténtalo más tarde.",
+        "noPendingRequestText": "Primero crea una solicitud de desbloqueo y espera a que tu compañer@ la apruebe antes de actualizar.",
+        "noApprovedRequestText": "Todavía no hay una solicitud aprobada. Espera a que tu compañer@ la apruebe e inténtalo de nuevo.",
         "aiBuddyWindowTitle": "Compañero de responsabilidad",
         "aiBuddyHeader": "Compañero de responsabilidad",
         "aiBuddyChecking": "Comprobando si vale la pena posponer tus hábitos…",

--- a/config/config.json
+++ b/config/config.json
@@ -3221,6 +3221,8 @@
         "pleaseWaitText": "Please wait for your buddy to accept the invitation before creating an unlock request.",
         "callBuddyText": "We suggest you call your buddy {0} and ask them to unlock. They'll have an email with instructions.",
         "requestFailedText": "Request Unlock Failed -  Please try again later",
+        "noPendingRequestText": "Please create an unlock request first, then wait for your buddy to approve it before refreshing.",
+        "noApprovedRequestText": "No approved request found yet. Please wait for your buddy to approve, then try again.",
         "aiBuddyWindowTitle": "Accountability Buddy",
         "aiBuddyHeader": "Accountability buddy",
         "aiBuddyChecking": "Checking whether that's worth postponing your habits…",


### PR DESCRIPTION
Adds two accountabilityBuddyInfo strings (EN + ES) for the Windows Accountability Buddy refresh fix — windows-app-v2#992, app PR: https://github.com/Focus-Bear/windows-app-v2/pull/1108

| key | EN | ES |
|---|---|---|
| `noPendingRequestText` | Please create an unlock request first, then wait for your buddy to approve it before refreshing. | Primero crea una solicitud de desbloqueo y espera a que tu compañer@ la apruebe antes de actualizar. |
| `noApprovedRequestText` | No approved request found yet. Please wait for your buddy to approve, then try again. | Todavía no hay una solicitud aprobada. Espera a que tu compañer@ la apruebe e inténtalo de nuevo. |